### PR TITLE
fix: boolean transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "zone.js": "0.15.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "19.6.1",
-    "@commitlint/config-conventional": "19.6.0",
     "@angular-devkit/build-angular": "19.0.6",
     "@angular/cli": "19.0.6",
     "@angular/compiler-cli": "19.0.5",
+    "@commitlint/cli": "19.6.1",
+    "@commitlint/config-conventional": "19.6.0",
     "@types/jasmine": "5.1.5",
     "@types/node": "22.10.5",
     "@web/test-runner": "0.19.0",

--- a/src/angular/core/attribute-transform.ts
+++ b/src/angular/core/attribute-transform.ts
@@ -4,5 +4,5 @@
  * which does not align with the Lit and native interpretation.
  */
 export function booleanAttribute(value: unknown): boolean {
-  return typeof value === 'boolean' ? value : value != null && !!value;
+  return typeof value === 'boolean' ? value : value !== undefined && value != null;
 }


### PR DESCRIPTION
Apparently, using something like this does not work

```
<sbb-radio-button value='1' allow-empty-selection> Value 1 <sbb-radio-button>
```

 because the value passed is an empty string, which is treated as `false` from `!!value`.