### PR TITLE
chore: fix storybook link

### DIFF
--- a/src/showcase/.storybook/preview-head.html
+++ b/src/showcase/.storybook/preview-head.html
@@ -45,7 +45,7 @@
         max-width: fit-content;
       `;
       const a = document.createElement('a');
-      a.href = 'https://lyne-storybook.app.sbb.ch/';
+      a.href = 'https://lyne-angular-storybook.app.sbb.ch/';
       a.textContent = '(Create your own)';
 
       const button = document.createElement('button');


### PR DESCRIPTION
Side note: the 'brandTitle' parameter seems not to work on https://lyne-angular-storybook.app.sbb.ch, but it does locally.