### PR TITLE
fix: remove output annotation to avoid duplicate events

### DIFF
--- a/src/angular/alert/alert-group/alert-group.ts
+++ b/src/angular/alert/alert-group/alert-group.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import type { SbbAlertGroupElement } from '@sbb-esta/lyne-elements/alert/alert-group.js';
 import { SbbTitleLevel } from '@sbb-esta/lyne-elements/title.js';
 import { fromEvent, type Observable } from 'rxjs';
@@ -38,5 +38,5 @@ export class SbbAlertGroup {
     return this.#element.nativeElement.accessibilityTitleLevel;
   }
 
-  @Output() public empty: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'empty');
+  public empty: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'empty');
 }

--- a/src/angular/alert/alert/alert.ts
+++ b/src/angular/alert/alert/alert.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbAlertElement } from '@sbb-esta/lyne-elements/alert/alert.js';
 import { SbbTitleLevel } from '@sbb-esta/lyne-elements/title.js';
@@ -60,25 +60,13 @@ export class SbbAlert {
     return this.#element.nativeElement.animation;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didClose',
-  );
+  public didClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didClose');
 
   public get isOpen(): boolean {
     return this.#element.nativeElement.isOpen;

--- a/src/angular/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.ts
+++ b/src/angular/autocomplete-grid/autocomplete-grid-option/autocomplete-grid-option.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbAutocompleteGridOptionElement } from '@sbb-esta/lyne-elements/autocomplete-grid/autocomplete-grid-option.js';
 import { fromEvent, type Observable } from 'rxjs';
@@ -46,12 +46,12 @@ export class SbbAutocompleteGridOption {
     return this.#element.nativeElement.selected;
   }
 
-  @Output() public autocompleteOptionSelectionChange: Observable<void> = fromEvent<void>(
+  public autocompleteOptionSelectionChange: Observable<void> = fromEvent<void>(
     this.#element.nativeElement,
     'autocompleteOptionSelectionChange',
   );
 
-  @Output() public autocompleteOptionSelected: Observable<void> = fromEvent<void>(
+  public autocompleteOptionSelected: Observable<void> = fromEvent<void>(
     this.#element.nativeElement,
     'autocompleteOptionSelected',
   );

--- a/src/angular/autocomplete-grid/autocomplete-grid/autocomplete-grid.ts
+++ b/src/angular/autocomplete-grid/autocomplete-grid/autocomplete-grid.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbAutocompleteGridElement } from '@sbb-esta/lyne-elements/autocomplete-grid/autocomplete-grid.js';
 import { fromEvent, type Observable } from 'rxjs';
@@ -44,25 +44,13 @@ export class SbbAutocompleteGrid {
     return this.#element.nativeElement.preserveIconSpace;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didClose',
-  );
+  public didClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didClose');
 
   public get originElement(): HTMLElement {
     return this.#element.nativeElement.originElement;

--- a/src/angular/autocomplete/autocomplete.ts
+++ b/src/angular/autocomplete/autocomplete.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbAutocompleteElement } from '@sbb-esta/lyne-elements/autocomplete.js';
 import { fromEvent, type Observable } from 'rxjs';
@@ -44,25 +44,13 @@ export class SbbAutocomplete {
     return this.#element.nativeElement.preserveIconSpace;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didClose',
-  );
+  public didClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didClose');
 
   public get originElement(): HTMLElement {
     return this.#element.nativeElement.originElement;

--- a/src/angular/calendar/calendar.ts
+++ b/src/angular/calendar/calendar.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { CalendarView, SbbCalendarElement } from '@sbb-esta/lyne-elements/calendar.js';
 import { SbbDateLike } from '@sbb-esta/lyne-elements/core/interfaces.js';
@@ -77,10 +77,7 @@ export class SbbCalendar<T = Date> {
     return this.#element.nativeElement.orientation;
   }
 
-  @Output() public dateSelected: Observable<T> = fromEvent<T>(
-    this.#element.nativeElement,
-    'dateSelected',
-  );
+  public dateSelected: Observable<T> = fromEvent<T>(this.#element.nativeElement, 'dateSelected');
 
   public resetPosition(): void {
     return this.#element.nativeElement.resetPosition();

--- a/src/angular/checkbox/checkbox-panel/checkbox-panel.ts
+++ b/src/angular/checkbox/checkbox-panel/checkbox-panel.ts
@@ -7,7 +7,6 @@ import {
   inject,
   Input,
   NgZone,
-  Output,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, SbbControlValueAccessorMixin } from '@sbb-esta/lyne-angular/core';
@@ -112,14 +111,9 @@ export class SbbCheckboxPanel
     return this.#element.nativeElement.value;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'change');
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public input: Observable<InputEvent> = fromEvent<InputEvent>(
+  public input: Observable<InputEvent> = fromEvent<InputEvent>(
     this.#element.nativeElement,
     'input',
   );

--- a/src/angular/checkbox/checkbox/checkbox.ts
+++ b/src/angular/checkbox/checkbox/checkbox.ts
@@ -7,7 +7,6 @@ import {
   inject,
   Input,
   NgZone,
-  Output,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, SbbControlValueAccessorMixin } from '@sbb-esta/lyne-angular/core';
@@ -110,14 +109,9 @@ export class SbbCheckbox extends SbbControlValueAccessorMixin(class {}) implemen
     return this.#element.nativeElement.iconName;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'change');
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public input: Observable<InputEvent> = fromEvent<InputEvent>(
+  public input: Observable<InputEvent> = fromEvent<InputEvent>(
     this.#element.nativeElement,
     'input',
   );

--- a/src/angular/container/sticky-bar/sticky-bar.ts
+++ b/src/angular/container/sticky-bar/sticky-bar.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import type { SbbStickyBarElement } from '@sbb-esta/lyne-elements/container/sticky-bar.js';
 import { fromEvent, type Observable } from 'rxjs';
 
@@ -19,25 +19,16 @@ export class SbbStickyBar {
     return this.#element.nativeElement.color;
   }
 
-  @Output() public willStick: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willStick',
-  );
+  public willStick: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willStick');
 
-  @Output() public didStick: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didStick',
-  );
+  public didStick: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didStick');
 
-  @Output() public willUnstick: Observable<void> = fromEvent<void>(
+  public willUnstick: Observable<void> = fromEvent<void>(
     this.#element.nativeElement,
     'willUnstick',
   );
 
-  @Output() public didUnstick: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didUnstick',
-  );
+  public didUnstick: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didUnstick');
 
   public stick(): void {
     return this.#element.nativeElement.stick();

--- a/src/angular/date-input/date-input.ts
+++ b/src/angular/date-input/date-input.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, NgZone, Output, inject, forwardRef } from '@angular/core';
+import { Directive, ElementRef, Input, NgZone, inject, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, SbbControlValueAccessorMixin } from '@sbb-esta/lyne-angular/core';
 import { readConfig } from '@sbb-esta/lyne-elements/core/config.js';
@@ -109,17 +109,12 @@ export class SbbDateInput<T = Date> extends SbbControlValueAccessorMixin(class {
     return this.#element.nativeElement.name;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public input: Observable<InputEvent> = fromEvent<InputEvent>(
+  public input: Observable<InputEvent> = fromEvent<InputEvent>(
     this.#element.nativeElement,
     'input',
   );
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'change');
 
   public get type(): string {
     return this.#element.nativeElement.type;

--- a/src/angular/datepicker/datepicker/datepicker.ts
+++ b/src/angular/datepicker/datepicker/datepicker.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import { SbbValidationChangeEvent } from '@sbb-esta/lyne-elements/core/interfaces.js';
 import { SbbDateInputElement } from '@sbb-esta/lyne-elements/date-input.js';
@@ -57,29 +57,21 @@ export class SbbDatepicker<T = Date> {
     return this.#element.nativeElement.valueAsDate;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'change');
 
-  // eslint-disable-next-line @angular-eslint/no-output-rename, @angular-eslint/no-output-native
-  @Output('input') public inputEvent: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'input',
-  );
+  public inputEvent: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'input');
 
-  @Output() public inputUpdated: Observable<SbbInputUpdateEvent> = fromEvent<SbbInputUpdateEvent>(
+  public inputUpdated: Observable<SbbInputUpdateEvent> = fromEvent<SbbInputUpdateEvent>(
     this.#element.nativeElement,
     'inputUpdated',
   );
 
-  @Output() public datePickerUpdated: Observable<void> = fromEvent<void>(
+  public datePickerUpdated: Observable<void> = fromEvent<void>(
     this.#element.nativeElement,
     'datePickerUpdated',
   );
 
-  @Output() public validationChange: Observable<SbbValidationChangeEvent> =
+  public validationChange: Observable<SbbValidationChangeEvent> =
     fromEvent<SbbValidationChangeEvent>(this.#element.nativeElement, 'validationChange');
 
   public get inputElement(): HTMLInputElement | SbbDateInputElement<T> | null {

--- a/src/angular/dialog/dialog-title/dialog-title.ts
+++ b/src/angular/dialog/dialog-title/dialog-title.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import { Breakpoint } from '@sbb-esta/lyne-elements/core/dom.js';
 import type { SbbDialogTitleElement } from '@sbb-esta/lyne-elements/dialog/dialog-title.js';
@@ -81,7 +81,7 @@ export class SbbDialogTitle {
     return this.#element.nativeElement.visuallyHidden;
   }
 
-  @Output() public requestBackAction: Observable<void> = fromEvent<void>(
+  public requestBackAction: Observable<void> = fromEvent<void>(
     this.#element.nativeElement,
     'requestBackAction',
   );

--- a/src/angular/dialog/dialog/dialog.ts
+++ b/src/angular/dialog/dialog/dialog.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import { SbbOverlayCloseEventDetails } from '@sbb-esta/lyne-elements/core/interfaces.js';
 import type { SbbDialogElement } from '@sbb-esta/lyne-elements/dialog/dialog.js';
@@ -44,23 +44,16 @@ export class SbbDialog {
     return this.#element.nativeElement.accessibilityLabel;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<SbbOverlayCloseEventDetails> =
-    fromEvent<SbbOverlayCloseEventDetails>(this.#element.nativeElement, 'didClose');
+  public didClose: Observable<SbbOverlayCloseEventDetails> = fromEvent<SbbOverlayCloseEventDetails>(
+    this.#element.nativeElement,
+    'didClose',
+  );
 
   public get isOpen(): boolean {
     return this.#element.nativeElement.isOpen;

--- a/src/angular/expansion-panel/expansion-panel-header/expansion-panel-header.ts
+++ b/src/angular/expansion-panel/expansion-panel-header/expansion-panel-header.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import { SbbButtonType } from '@sbb-esta/lyne-elements/core/base-elements.js';
 import type { SbbExpansionPanelHeaderElement } from '@sbb-esta/lyne-elements/expansion-panel/expansion-panel-header.js';
@@ -70,7 +70,7 @@ export class SbbExpansionPanelHeader {
     return this.#element.nativeElement.type;
   }
 
-  @Output() public toggleExpanded: Observable<void> = fromEvent<void>(
+  public toggleExpanded: Observable<void> = fromEvent<void>(
     this.#element.nativeElement,
     'toggleExpanded',
   );

--- a/src/angular/expansion-panel/expansion-panel/expansion-panel.ts
+++ b/src/angular/expansion-panel/expansion-panel/expansion-panel.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbExpansionPanelElement } from '@sbb-esta/lyne-elements/expansion-panel/expansion-panel.js';
 import { SbbTitleLevel } from '@sbb-esta/lyne-elements/title.js';
@@ -60,23 +60,11 @@ export class SbbExpansionPanel {
     return this.#element.nativeElement.size;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didClose',
-  );
+  public didClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didClose');
 }

--- a/src/angular/file-selector/file-selector-dropzone/file-selector-dropzone.ts
+++ b/src/angular/file-selector/file-selector-dropzone/file-selector-dropzone.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, forwardRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, forwardRef, inject, Input, NgZone } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, SbbControlValueAccessorMixin } from '@sbb-esta/lyne-angular/core';
 import type { SbbFileSelectorDropzoneElement } from '@sbb-esta/lyne-elements/file-selector/file-selector-dropzone.js';
@@ -107,22 +107,14 @@ export class SbbFileSelectorDropzone extends SbbControlValueAccessorMixin(class 
     return this.#element.nativeElement.name;
   }
 
-  @Output() public fileChanged: Observable<readonly File[]> = fromEvent<readonly File[]>(
+  public fileChanged: Observable<readonly File[]> = fromEvent<readonly File[]>(
     this.#element.nativeElement,
     'fileChanged',
   );
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'change');
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public input: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'input',
-  );
+  public input: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'input');
 
   public get type(): string {
     return this.#element.nativeElement.type;

--- a/src/angular/file-selector/file-selector/file-selector.ts
+++ b/src/angular/file-selector/file-selector/file-selector.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, forwardRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, forwardRef, inject, Input, NgZone } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, SbbControlValueAccessorMixin } from '@sbb-esta/lyne-angular/core';
 import type { SbbFileSelectorElement } from '@sbb-esta/lyne-elements/file-selector/file-selector.js';
@@ -97,22 +97,14 @@ export class SbbFileSelector extends SbbControlValueAccessorMixin(class {}) {
     return this.#element.nativeElement.name;
   }
 
-  @Output() public fileChanged: Observable<readonly File[]> = fromEvent<readonly File[]>(
+  public fileChanged: Observable<readonly File[]> = fromEvent<readonly File[]>(
     this.#element.nativeElement,
     'fileChanged',
   );
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'change');
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public input: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'input',
-  );
+  public input: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'input');
 
   public get type(): string {
     return this.#element.nativeElement.type;

--- a/src/angular/flip-card/flip-card/flip-card.ts
+++ b/src/angular/flip-card/flip-card/flip-card.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { SbbFlipCardSummaryElement } from '@sbb-esta/lyne-elements/flip-card/flip-card-summary.js';
 import type { SbbFlipCardElement } from '@sbb-esta/lyne-elements/flip-card/flip-card.js';
 import { SbbFlipCardDetailsElement } from '@sbb-esta/lyne-elements/flip-card.js';
@@ -20,7 +20,7 @@ export class SbbFlipCard {
     return this.#element.nativeElement.accessibilityLabel;
   }
 
-  @Output() public flip: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'flip');
+  public flip: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'flip');
 
   public get summary(): SbbFlipCardSummaryElement | null {
     return this.#element.nativeElement.summary;

--- a/src/angular/image/image.ts
+++ b/src/angular/image/image.ts
@@ -1,12 +1,4 @@
-import {
-  Directive,
-  ElementRef,
-  inject,
-  Input,
-  NgZone,
-  numberAttribute,
-  Output,
-} from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone, numberAttribute } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbImageElement } from '@sbb-esta/lyne-elements/image.js';
 import { fromEvent, type Observable } from 'rxjs';
@@ -115,14 +107,9 @@ export class SbbImage {
     return this.#element.nativeElement.pictureSizesConfig;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public load: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'load');
+  public load: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'load');
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public error: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'error',
-  );
+  public error: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'error');
 
   public get complete(): boolean {
     return this.#element.nativeElement.complete;

--- a/src/angular/menu/menu/menu.ts
+++ b/src/angular/menu/menu/menu.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import type { SbbMenuElement } from '@sbb-esta/lyne-elements/menu/menu.js';
 import { fromEvent, type Observable } from 'rxjs';
 import '@sbb-esta/lyne-elements/menu/menu.js';
@@ -28,25 +28,13 @@ export class SbbMenu {
     return this.#element.nativeElement.listAccessibilityLabel;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didClose',
-  );
+  public didClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didClose');
 
   public get isOpen(): boolean {
     return this.#element.nativeElement.isOpen;

--- a/src/angular/navigation/navigation/navigation.ts
+++ b/src/angular/navigation/navigation/navigation.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import type { SbbNavigationElement } from '@sbb-esta/lyne-elements/navigation/navigation.js';
 import { fromEvent, type Observable } from 'rxjs';
 import '@sbb-esta/lyne-elements/navigation/navigation.js';
@@ -28,25 +28,13 @@ export class SbbNavigation {
     return this.#element.nativeElement.accessibilityCloseLabel;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didClose',
-  );
+  public didClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didClose');
 
   public get activeNavigationSection(): HTMLElement | null {
     return this.#element.nativeElement.activeNavigationSection;

--- a/src/angular/notification/notification.ts
+++ b/src/angular/notification/notification.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbNotificationElement } from '@sbb-esta/lyne-elements/notification.js';
 import { SbbTitleLevel } from '@sbb-esta/lyne-elements/title.js';
@@ -60,25 +60,13 @@ export class SbbNotification {
     return this.#element.nativeElement.animation;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didClose',
-  );
+  public didClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didClose');
 
   public close(): void {
     return this.#element.nativeElement.close();

--- a/src/angular/option/option/option.ts
+++ b/src/angular/option/option/option.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbOptionElement } from '@sbb-esta/lyne-elements/option/option.js';
 import { fromEvent, type Observable } from 'rxjs';
@@ -43,12 +43,12 @@ export class SbbOption {
     return this.#element.nativeElement.selected;
   }
 
-  @Output() public optionSelectionChange: Observable<void> = fromEvent<void>(
+  public optionSelectionChange: Observable<void> = fromEvent<void>(
     this.#element.nativeElement,
     'optionSelectionChange',
   );
 
-  @Output() public optionSelected: Observable<void> = fromEvent<void>(
+  public optionSelected: Observable<void> = fromEvent<void>(
     this.#element.nativeElement,
     'optionSelected',
   );

--- a/src/angular/overlay/overlay.ts
+++ b/src/angular/overlay/overlay.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import { SbbOverlayCloseEventDetails } from '@sbb-esta/lyne-elements/core/interfaces.js';
 import type { SbbOverlayElement } from '@sbb-esta/lyne-elements/overlay.js';
@@ -64,25 +64,18 @@ export class SbbOverlay {
     return this.#element.nativeElement.accessibilityLabel;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
+
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
+
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
+
+  public didClose: Observable<SbbOverlayCloseEventDetails> = fromEvent<SbbOverlayCloseEventDetails>(
     this.#element.nativeElement,
-    'willOpen',
+    'didClose',
   );
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
-
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
-
-  @Output() public didClose: Observable<SbbOverlayCloseEventDetails> =
-    fromEvent<SbbOverlayCloseEventDetails>(this.#element.nativeElement, 'didClose');
-
-  @Output() public requestBackAction: Observable<void> = fromEvent<void>(
+  public requestBackAction: Observable<void> = fromEvent<void>(
     this.#element.nativeElement,
     'requestBackAction',
   );

--- a/src/angular/paginator/compact-paginator/compact-paginator.ts
+++ b/src/angular/paginator/compact-paginator/compact-paginator.ts
@@ -1,12 +1,4 @@
-import {
-  Directive,
-  ElementRef,
-  inject,
-  Input,
-  NgZone,
-  numberAttribute,
-  Output,
-} from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone, numberAttribute } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import { SbbPaginatorPageEventDetails } from '@sbb-esta/lyne-elements/core/interfaces.js';
 import type { SbbCompactPaginatorElement } from '@sbb-esta/lyne-elements/paginator/compact-paginator.js';
@@ -76,6 +68,8 @@ export class SbbCompactPaginator {
     return this.#element.nativeElement.disabled;
   }
 
-  @Output() public page: Observable<SbbPaginatorPageEventDetails> =
-    fromEvent<SbbPaginatorPageEventDetails>(this.#element.nativeElement, 'page');
+  public page: Observable<SbbPaginatorPageEventDetails> = fromEvent<SbbPaginatorPageEventDetails>(
+    this.#element.nativeElement,
+    'page',
+  );
 }

--- a/src/angular/paginator/paginator/paginator.ts
+++ b/src/angular/paginator/paginator/paginator.ts
@@ -1,12 +1,4 @@
-import {
-  Directive,
-  ElementRef,
-  inject,
-  Input,
-  NgZone,
-  numberAttribute,
-  Output,
-} from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone, numberAttribute } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import { SbbPaginatorPageEventDetails } from '@sbb-esta/lyne-elements/core/interfaces.js';
 import type { SbbPaginatorElement } from '@sbb-esta/lyne-elements/paginator/paginator.js';
@@ -84,6 +76,8 @@ export class SbbPaginator {
     return this.#element.nativeElement.disabled;
   }
 
-  @Output() public page: Observable<SbbPaginatorPageEventDetails> =
-    fromEvent<SbbPaginatorPageEventDetails>(this.#element.nativeElement, 'page');
+  public page: Observable<SbbPaginatorPageEventDetails> = fromEvent<SbbPaginatorPageEventDetails>(
+    this.#element.nativeElement,
+    'page',
+  );
 }

--- a/src/angular/popover/popover/popover.ts
+++ b/src/angular/popover/popover/popover.ts
@@ -1,12 +1,4 @@
-import {
-  Directive,
-  ElementRef,
-  inject,
-  Input,
-  NgZone,
-  numberAttribute,
-  Output,
-} from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone, numberAttribute } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbPopoverElement } from '@sbb-esta/lyne-elements/popover/popover.js';
 import { fromEvent, type Observable } from 'rxjs';
@@ -69,21 +61,15 @@ export class SbbPopover {
     return this.#element.nativeElement.accessibilityCloseLabel;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<{ closeTarget: HTMLElement }> = fromEvent<{
+  public willClose: Observable<{ closeTarget: HTMLElement }> = fromEvent<{
     closeTarget: HTMLElement;
   }>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<{ closeTarget: HTMLElement }> = fromEvent<{
+  public didClose: Observable<{ closeTarget: HTMLElement }> = fromEvent<{
     closeTarget: HTMLElement;
   }>(this.#element.nativeElement, 'didClose');
 

--- a/src/angular/radio-button/radio-button-group/radio-button-group.ts
+++ b/src/angular/radio-button/radio-button-group/radio-button-group.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, forwardRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, forwardRef, inject, Input, NgZone } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, SbbControlValueAccessorMixin } from '@sbb-esta/lyne-angular/core';
 import type { SbbHorizontalFrom, SbbOrientation } from '@sbb-esta/lyne-elements/core/interfaces.js';
@@ -95,10 +95,7 @@ export class SbbRadioButtonGroup extends SbbControlValueAccessorMixin(class {}) 
     return this.#element.nativeElement.disabled;
   }
 
-  @Output() public didChange: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didChange',
-  );
+  public didChange: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didChange');
 
   public get radioButtons(): (SbbRadioButtonElement | SbbRadioButtonPanelElement)[] {
     return this.#element.nativeElement.radioButtons;

--- a/src/angular/radio-button/radio-button-panel/radio-button-panel.ts
+++ b/src/angular/radio-button/radio-button-panel/radio-button-panel.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import { SbbPanelSize } from '@sbb-esta/lyne-elements/core/mixins.js';
 import type { SbbRadioButtonPanelElement } from '@sbb-esta/lyne-elements/radio-button/radio-button-panel.js';
@@ -87,14 +87,9 @@ export class SbbRadioButtonPanel {
     return this.#element.nativeElement.value;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'change');
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public input: Observable<InputEvent> = fromEvent<InputEvent>(
+  public input: Observable<InputEvent> = fromEvent<InputEvent>(
     this.#element.nativeElement,
     'input',
   );

--- a/src/angular/radio-button/radio-button/radio-button.ts
+++ b/src/angular/radio-button/radio-button/radio-button.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbRadioButtonElement } from '@sbb-esta/lyne-elements/radio-button/radio-button.js';
 import type {
@@ -73,14 +73,9 @@ export class SbbRadioButton {
     return this.#element.nativeElement.value;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'change');
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public input: Observable<InputEvent> = fromEvent<InputEvent>(
+  public input: Observable<InputEvent> = fromEvent<InputEvent>(
     this.#element.nativeElement,
     'input',
   );

--- a/src/angular/select/select.ts
+++ b/src/angular/select/select.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, forwardRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, forwardRef, inject, Input, NgZone } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, SbbControlValueAccessorMixin } from '@sbb-esta/lyne-angular/core';
 import type { SbbSelectElement } from '@sbb-esta/lyne-elements/select.js';
@@ -90,34 +90,17 @@ export class SbbSelect extends SbbControlValueAccessorMixin(class {}) {
     return this.#element.nativeElement.value;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'change');
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public input: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'input');
+  public input: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'input');
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didClose',
-  );
+  public didClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didClose');
 
   public get type(): string {
     return this.#element.nativeElement.type;

--- a/src/angular/selection-expansion-panel/selection-expansion-panel.ts
+++ b/src/angular/selection-expansion-panel/selection-expansion-panel.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbSelectionExpansionPanelElement } from '@sbb-esta/lyne-elements/selection-expansion-panel.js';
 import { fromEvent, type Observable } from 'rxjs';
@@ -37,23 +37,11 @@ export class SbbSelectionExpansionPanel {
     return this.#element.nativeElement.borderless;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didClose',
-  );
+  public didClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didClose');
 }

--- a/src/angular/slider/slider.ts
+++ b/src/angular/slider/slider.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, forwardRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, forwardRef, inject, Input, NgZone } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, SbbControlValueAccessorMixin } from '@sbb-esta/lyne-angular/core';
 import type { SbbSliderElement } from '@sbb-esta/lyne-elements/slider.js';
@@ -97,10 +97,7 @@ export class SbbSlider extends SbbControlValueAccessorMixin(class {}) {
     return this.#element.nativeElement.name;
   }
 
-  @Output() public didChange: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didChange',
-  );
+  public didChange: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didChange');
 
   public get type(): string {
     return this.#element.nativeElement.type;

--- a/src/angular/stepper/step/step.ts
+++ b/src/angular/stepper/step/step.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Output } from '@angular/core';
+import { Directive, ElementRef, inject } from '@angular/core';
 import { SbbStepLabelElement } from '@sbb-esta/lyne-elements/stepper/step-label.js';
 import type {
   SbbStepElement,
@@ -13,8 +13,10 @@ import '@sbb-esta/lyne-elements/stepper/step.js';
 export class SbbStep {
   #element: ElementRef<SbbStepElement> = inject(ElementRef<SbbStepElement>);
 
-  @Output() public validate: Observable<SbbStepValidateEventDetails> =
-    fromEvent<SbbStepValidateEventDetails>(this.#element.nativeElement, 'validate');
+  public validate: Observable<SbbStepValidateEventDetails> = fromEvent<SbbStepValidateEventDetails>(
+    this.#element.nativeElement,
+    'validate',
+  );
 
   public get label(): SbbStepLabelElement | null {
     return this.#element.nativeElement.label;

--- a/src/angular/tabs/tab-group/tab-group.ts
+++ b/src/angular/tabs/tab-group/tab-group.ts
@@ -1,12 +1,4 @@
-import {
-  Directive,
-  ElementRef,
-  inject,
-  Input,
-  NgZone,
-  numberAttribute,
-  Output,
-} from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone, numberAttribute } from '@angular/core';
 import type {
   InterfaceSbbTabGroupTab,
   SbbTabChangedEventDetails,
@@ -40,8 +32,10 @@ export class SbbTabGroup {
     return this.#element.nativeElement.initialSelectedIndex;
   }
 
-  @Output() public didChange: Observable<SbbTabChangedEventDetails> =
-    fromEvent<SbbTabChangedEventDetails>(this.#element.nativeElement, 'didChange');
+  public didChange: Observable<SbbTabChangedEventDetails> = fromEvent<SbbTabChangedEventDetails>(
+    this.#element.nativeElement,
+    'didChange',
+  );
 
   public disableTab(tabIndex: number): void {
     return this.#element.nativeElement.disableTab(tabIndex);

--- a/src/angular/tag/tag/tag.ts
+++ b/src/angular/tag/tag/tag.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import { SbbButtonType } from '@sbb-esta/lyne-elements/core/base-elements.js';
 import type { SbbTagElement, SbbTagSize } from '@sbb-esta/lyne-elements/tag/tag.js';
@@ -93,19 +93,11 @@ export class SbbTag {
     return this.#element.nativeElement.type;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public input: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'input');
+  public input: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'input');
 
-  @Output() public didChange: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didChange',
-  );
+  public didChange: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didChange');
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'change');
 
   public get validity(): ValidityState {
     return this.#element.nativeElement.validity;

--- a/src/angular/time-input/time-input.ts
+++ b/src/angular/time-input/time-input.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
 import { SbbValidationChangeEvent } from '@sbb-esta/lyne-elements/core/interfaces.js';
 import type { SbbTimeInputElement } from '@sbb-esta/lyne-elements/time-input.js';
 import { fromEvent, type Observable } from 'rxjs';
@@ -27,11 +27,8 @@ export class SbbTimeInput {
     return this.#element.nativeElement.valueAsDate;
   }
 
-  @Output() public didChange: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didChange',
-  );
+  public didChange: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didChange');
 
-  @Output() public validationChange: Observable<SbbValidationChangeEvent> =
+  public validationChange: Observable<SbbValidationChangeEvent> =
     fromEvent<SbbValidationChangeEvent>(this.#element.nativeElement, 'validationChange');
 }

--- a/src/angular/toast/toast.ts
+++ b/src/angular/toast/toast.ts
@@ -1,12 +1,4 @@
-import {
-  Directive,
-  ElementRef,
-  inject,
-  Input,
-  NgZone,
-  numberAttribute,
-  Output,
-} from '@angular/core';
+import { Directive, ElementRef, inject, Input, NgZone, numberAttribute } from '@angular/core';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbToastElement, SbbToastPosition } from '@sbb-esta/lyne-elements/toast.js';
 import { fromEvent, type Observable } from 'rxjs';
@@ -59,25 +51,13 @@ export class SbbToast {
     return this.#element.nativeElement.iconName;
   }
 
-  @Output() public willOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willOpen',
-  );
+  public willOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willOpen');
 
-  @Output() public didOpen: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didOpen',
-  );
+  public didOpen: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didOpen');
 
-  @Output() public willClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'willClose',
-  );
+  public willClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'willClose');
 
-  @Output() public didClose: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'didClose',
-  );
+  public didClose: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'didClose');
 
   public get isOpen(): boolean {
     return this.#element.nativeElement.isOpen;

--- a/src/angular/toggle-check/toggle-check.ts
+++ b/src/angular/toggle-check/toggle-check.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, forwardRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, forwardRef, inject, Input, NgZone } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, SbbControlValueAccessorMixin } from '@sbb-esta/lyne-angular/core';
 import type { SbbToggleCheckElement } from '@sbb-esta/lyne-elements/toggle-check.js';
@@ -89,14 +89,9 @@ export class SbbToggleCheck extends SbbControlValueAccessorMixin(class {}) {
     return this.#element.nativeElement.value;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<Event> = fromEvent<Event>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<Event> = fromEvent<Event>(this.#element.nativeElement, 'change');
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public input: Observable<InputEvent> = fromEvent<InputEvent>(
+  public input: Observable<InputEvent> = fromEvent<InputEvent>(
     this.#element.nativeElement,
     'input',
   );

--- a/src/angular/toggle/toggle/toggle.ts
+++ b/src/angular/toggle/toggle/toggle.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, forwardRef, inject, Input, NgZone, Output } from '@angular/core';
+import { Directive, ElementRef, forwardRef, inject, Input, NgZone } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, SbbControlValueAccessorMixin } from '@sbb-esta/lyne-angular/core';
 import { SbbToggleOptionElement } from '@sbb-esta/lyne-elements/toggle/toggle-option.js';
@@ -58,11 +58,7 @@ export class SbbToggle extends SbbControlValueAccessorMixin(class {}) {
     return this.#element.nativeElement.value;
   }
 
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() public change: Observable<void> = fromEvent<void>(
-    this.#element.nativeElement,
-    'change',
-  );
+  public change: Observable<void> = fromEvent<void>(this.#element.nativeElement, 'change');
 
   public get options(): SbbToggleOptionElement[] {
     return this.#element.nativeElement.options;


### PR DESCRIPTION
This PR temporary solves the issue of the triggering of duplicate events; however IDE autocompletion won't recognize events anymore.

In a future PR the following syntax can be used (the following code relates to the angular-storybook-generator file) to correctly manage events and have IDE autocompletion:

```
@Output('${member.name}') protected '_${member.name}': (typeof this)['${member.name}'] = NEVER;

${member.name}: Observable<CustomEvent<${type}>> = fromEvent<${type}>(this.#element.nativeElement, '${member.name}');
```