### PR TITLE
build: replace actions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,10 +37,10 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.MAINTENANCE_APP_ID }}
-          private_key: ${{ secrets.MAINTENANCE_APP_PEM }}
+          app-id: ${{ secrets.MAINTENANCE_APP_ID }}
+          private-key: ${{ secrets.MAINTENANCE_APP_PEM }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
Changes:
- the tibdex/github-app-token action has been replaced by the official Github one.