### PR TITLE
build: fix action for adding issues to Lyne board

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -14,7 +14,9 @@ jobs:
           app-id: ${{ secrets.MAINTENANCE_APP_ID }}
           private-key: ${{ secrets.MAINTENANCE_APP_PEM }}
       - name: Add issue
+        env:
+          TOKEN: ${{ steps.generate_token.outputs.token }}
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/sbb-design-systems/projects/4
-          github-token: ${{ steps.generate_token.outputs.token }}
+          github-token: ${{ env.TOKEN }}


### PR DESCRIPTION
Apparently, the action that should add lyne-angular issues to the Lyne board is failing:
https://github.com/sbb-design-systems/lyne-angular/actions/runs/15383673720/job/43278407787

This pr is a try to fix it by redefining the token in the env