### PR TITLE
refactor: add string type to element references properties

### DIFF
--- a/src/angular/autocomplete-grid/autocomplete-grid/autocomplete-grid.ts
+++ b/src/angular/autocomplete-grid/autocomplete-grid/autocomplete-grid.ts
@@ -33,16 +33,20 @@ export class SbbAutocompleteGrid<T = string> {
   }
 
   @Input()
-  public set origin(value: HTMLElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.origin = value));
+  public set origin(value: string | HTMLElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.origin = value as HTMLElement | null),
+    );
   }
   public get origin(): HTMLElement | null {
     return this.#element.nativeElement.origin;
   }
 
   @Input()
-  public set trigger(value: HTMLInputElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.trigger = value));
+  public set trigger(value: string | HTMLInputElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.trigger = value as HTMLInputElement | null),
+    );
   }
   public get trigger(): HTMLInputElement | null {
     return this.#element.nativeElement.trigger;

--- a/src/angular/autocomplete/autocomplete.ts
+++ b/src/angular/autocomplete/autocomplete.ts
@@ -31,16 +31,20 @@ export class SbbAutocomplete<T = string> {
   }
 
   @Input()
-  public set origin(value: HTMLElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.origin = value));
+  public set origin(value: string | HTMLElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.origin = value as HTMLElement | null),
+    );
   }
   public get origin(): HTMLElement | null {
     return this.#element.nativeElement.origin;
   }
 
   @Input()
-  public set trigger(value: HTMLInputElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.trigger = value));
+  public set trigger(value: string | HTMLInputElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.trigger = value as HTMLInputElement | null),
+    );
   }
   public get trigger(): HTMLInputElement | null {
     return this.#element.nativeElement.trigger;

--- a/src/angular/datepicker/datepicker-next-day/datepicker-next-day.ts
+++ b/src/angular/datepicker/datepicker-next-day/datepicker-next-day.ts
@@ -25,8 +25,10 @@ export class SbbDatepickerNextDay<T = Date> {
   }
 
   @Input()
-  public set input(value: SbbDateInputElement<T> | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.input = value));
+  public set input(value: string | SbbDateInputElement<T> | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.input = value as SbbDateInputElement<T> | null),
+    );
   }
   public get input(): SbbDateInputElement<T> | null {
     return this.#element.nativeElement.input;

--- a/src/angular/datepicker/datepicker-previous-day/datepicker-previous-day.ts
+++ b/src/angular/datepicker/datepicker-previous-day/datepicker-previous-day.ts
@@ -25,8 +25,10 @@ export class SbbDatepickerPreviousDay<T = Date> {
   }
 
   @Input()
-  public set input(value: SbbDateInputElement<T> | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.input = value));
+  public set input(value: string | SbbDateInputElement<T> | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.input = value as SbbDateInputElement<T> | null),
+    );
   }
   public get input(): SbbDateInputElement<T> | null {
     return this.#element.nativeElement.input;

--- a/src/angular/datepicker/datepicker-toggle/datepicker-toggle.ts
+++ b/src/angular/datepicker/datepicker-toggle/datepicker-toggle.ts
@@ -18,8 +18,10 @@ export class SbbDatepickerToggle<T = Date> {
   #ngZone: NgZone = inject(NgZone);
 
   @Input()
-  public set datepicker(value: SbbDatepickerElement<T> | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.datepicker = value));
+  public set datepicker(value: string | SbbDatepickerElement<T> | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.datepicker = value as SbbDatepickerElement<T> | null),
+    );
   }
   public get datepicker(): SbbDatepickerElement<T> | null {
     return this.#element.nativeElement.datepicker;
@@ -34,8 +36,10 @@ export class SbbDatepickerToggle<T = Date> {
   }
 
   @Input()
-  public set input(value: SbbDateInputElement<T> | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.input = value));
+  public set input(value: string | SbbDateInputElement<T> | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.input = value as SbbDateInputElement<T> | null),
+    );
   }
   public get input(): SbbDateInputElement<T> | null {
     return this.#element.nativeElement.input;

--- a/src/angular/datepicker/datepicker/datepicker.ts
+++ b/src/angular/datepicker/datepicker/datepicker.ts
@@ -25,8 +25,10 @@ export class SbbDatepicker<T = Date> {
   }
 
   @Input()
-  public set input(value: SbbDateInputElement<T> | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.input = value));
+  public set input(value: string | SbbDateInputElement<T> | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.input = value as SbbDateInputElement<T> | null),
+    );
   }
   public get input(): SbbDateInputElement<T> | null {
     return this.#element.nativeElement.input;
@@ -41,8 +43,10 @@ export class SbbDatepicker<T = Date> {
   }
 
   @Input()
-  public set trigger(value: HTMLElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.trigger = value));
+  public set trigger(value: string | HTMLElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.trigger = value as HTMLElement | null),
+    );
   }
   public get trigger(): HTMLElement | null {
     return this.#element.nativeElement.trigger;

--- a/src/angular/dialog/dialog/dialog.ts
+++ b/src/angular/dialog/dialog/dialog.ts
@@ -40,8 +40,10 @@ export class SbbDialog {
   }
 
   @Input()
-  public set trigger(value: HTMLElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.trigger = value));
+  public set trigger(value: string | HTMLElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.trigger = value as HTMLElement | null),
+    );
   }
   public get trigger(): HTMLElement | null {
     return this.#element.nativeElement.trigger;

--- a/src/angular/header/header/header.ts
+++ b/src/angular/header/header/header.ts
@@ -21,8 +21,10 @@ export class SbbHeader {
   }
 
   @Input()
-  public set scrollOrigin(value: HTMLElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.scrollOrigin = value));
+  public set scrollOrigin(value: string | HTMLElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.scrollOrigin = value as HTMLElement | null),
+    );
   }
   public get scrollOrigin(): HTMLElement | null {
     return this.#element.nativeElement.scrollOrigin;

--- a/src/angular/menu/menu/menu.ts
+++ b/src/angular/menu/menu/menu.ts
@@ -14,8 +14,10 @@ export class SbbMenu {
   #ngZone: NgZone = inject(NgZone);
 
   @Input()
-  public set trigger(value: HTMLElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.trigger = value));
+  public set trigger(value: string | HTMLElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.trigger = value as HTMLElement | null),
+    );
   }
   public get trigger(): HTMLElement | null {
     return this.#element.nativeElement.trigger;

--- a/src/angular/navigation/navigation-section/navigation-section.ts
+++ b/src/angular/navigation/navigation-section/navigation-section.ts
@@ -22,8 +22,10 @@ export class SbbNavigationSection {
   }
 
   @Input()
-  public set trigger(value: HTMLElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.trigger = value));
+  public set trigger(value: string | HTMLElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.trigger = value as HTMLElement | null),
+    );
   }
   public get trigger(): HTMLElement | null {
     return this.#element.nativeElement.trigger;

--- a/src/angular/navigation/navigation/navigation.ts
+++ b/src/angular/navigation/navigation/navigation.ts
@@ -14,8 +14,10 @@ export class SbbNavigation {
   #ngZone: NgZone = inject(NgZone);
 
   @Input()
-  public set trigger(value: HTMLElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.trigger = value));
+  public set trigger(value: string | HTMLElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.trigger = value as HTMLElement | null),
+    );
   }
   public get trigger(): HTMLElement | null {
     return this.#element.nativeElement.trigger;

--- a/src/angular/overlay/overlay.ts
+++ b/src/angular/overlay/overlay.ts
@@ -42,8 +42,10 @@ export class SbbOverlay {
   }
 
   @Input()
-  public set trigger(value: HTMLElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.trigger = value));
+  public set trigger(value: string | HTMLElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.trigger = value as HTMLElement | null),
+    );
   }
   public get trigger(): HTMLElement | null {
     return this.#element.nativeElement.trigger;

--- a/src/angular/popover/popover/popover.ts
+++ b/src/angular/popover/popover/popover.ts
@@ -15,8 +15,10 @@ export class SbbPopover {
   #ngZone: NgZone = inject(NgZone);
 
   @Input()
-  public set trigger(value: HTMLElement | null) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.trigger = value));
+  public set trigger(value: string | HTMLElement | null) {
+    this.#ngZone.runOutsideAngular(
+      () => (this.#element.nativeElement.trigger = value as HTMLElement | null),
+    );
   }
   public get trigger(): HTMLElement | null {
     return this.#element.nativeElement.trigger;

--- a/tools/eslint/angular-generator-rule.ts
+++ b/tools/eslint/angular-generator-rule.ts
@@ -308,14 +308,19 @@ export class ${className}${classDeclaration.classGenerics ? `<${classDeclaration
                 }
                 input += `)`;
 
+                const type = member.type?.text ?? 'any';
+                const setterType = type.match(/(Sbb|HTML)[a-zA-Z]*Element/)
+                  ? `string | ${type}`
+                  : type;
+                const typeCast = type === setterType ? '' : ` as ${type}`;
                 return fixer.insertTextBeforeRange(
                   [endOfBody, endOfBody],
                   `
   ${input}
-  public set ${member.name}(value: ${member.type?.text ?? 'any'}) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.${member.name} = value));
+  public set ${member.name}(value: ${setterType}) {
+    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.${member.name} = value${typeCast}));
   }
-  public get ${member.name}(): ${member.type?.text ?? 'any'} {
+  public get ${member.name}(): ${type} {
     return this.#element.nativeElement.${member.name};
   }\n`,
                 );


### PR DESCRIPTION
Currently trying to assign id reference properties via Angular HTML templates fail, as the type does not allow string. To solve this, we add the string type to the setters of id reference properties.