### PR TITLE
fix: declare modules as const

### DIFF
--- a/scripts/migrate-modules.mts
+++ b/scripts/migrate-modules.mts
@@ -167,7 +167,7 @@ function writeAngularModule(
 
   const content = `${importLines.join('\n')}
 
-export const Sbb${moduleName}Module = [${classNames.join(', ')}];
+export const Sbb${moduleName}Module = [${classNames.join(', ')}] as const;
 `;
   writeFileSync(join(moduleRoot, `${moduleFileName}.ts`), content.trim() + '\n');
 }

--- a/src/angular-experimental/seat-reservation/seat-reservation.module.ts
+++ b/src/angular-experimental/seat-reservation/seat-reservation.module.ts
@@ -14,4 +14,4 @@ export const SbbSeatReservationModule = [
   SbbSeatReservationNavigationServices,
   SbbSeatReservationPlaceControl,
   SbbSeatReservationScoped,
-];
+] as const;

--- a/src/angular/accordion/accordion.module.ts
+++ b/src/angular/accordion/accordion.module.ts
@@ -2,4 +2,4 @@ import { SbbExpansionPanelModule } from '@sbb-esta/lyne-angular/expansion-panel'
 
 import { SbbAccordion } from './accordion';
 
-export const SbbAccordionModule = [SbbAccordion, SbbExpansionPanelModule];
+export const SbbAccordionModule = [SbbAccordion, SbbExpansionPanelModule] as const;

--- a/src/angular/alert/alert.module.ts
+++ b/src/angular/alert/alert.module.ts
@@ -1,4 +1,4 @@
 import { SbbAlert } from './alert/alert';
 import { SbbAlertGroup } from './alert-group/alert-group';
 
-export const SbbAlertModule = [SbbAlert, SbbAlertGroup];
+export const SbbAlertModule = [SbbAlert, SbbAlertGroup] as const;

--- a/src/angular/autocomplete-grid/autocomplete-grid.module.ts
+++ b/src/angular/autocomplete-grid/autocomplete-grid.module.ts
@@ -15,4 +15,4 @@ export const SbbAutocompleteGridModule = [
   SbbAutocompleteGridOptgroup,
   SbbAutocompleteGridOption,
   SbbAutocompleteGridRow,
-];
+] as const;

--- a/src/angular/autocomplete/autocomplete.module.ts
+++ b/src/angular/autocomplete/autocomplete.module.ts
@@ -3,4 +3,8 @@ import { SbbOptionModule } from '@sbb-esta/lyne-angular/option';
 import { SbbAutocomplete } from './autocomplete';
 import { SbbAutocompleteTrigger } from './autocomplete-trigger';
 
-export const SbbAutocompleteModule = [SbbAutocompleteTrigger, SbbAutocomplete, SbbOptionModule];
+export const SbbAutocompleteModule = [
+  SbbAutocompleteTrigger,
+  SbbAutocomplete,
+  SbbOptionModule,
+] as const;

--- a/src/angular/breadcrumb/breadcrumb.module.ts
+++ b/src/angular/breadcrumb/breadcrumb.module.ts
@@ -1,4 +1,4 @@
 import { SbbBreadcrumb } from './breadcrumb/breadcrumb';
 import { SbbBreadcrumbGroup } from './breadcrumb-group/breadcrumb-group';
 
-export const SbbBreadcrumbModule = [SbbBreadcrumb, SbbBreadcrumbGroup];
+export const SbbBreadcrumbModule = [SbbBreadcrumb, SbbBreadcrumbGroup] as const;

--- a/src/angular/card/card.module.ts
+++ b/src/angular/card/card.module.ts
@@ -3,4 +3,4 @@ import { SbbCardBadge } from './card-badge/card-badge';
 import { SbbCardButton } from './card-button/card-button';
 import { SbbCardLink } from './card-link/card-link';
 
-export const SbbCardModule = [SbbCard, SbbCardBadge, SbbCardButton, SbbCardLink];
+export const SbbCardModule = [SbbCard, SbbCardBadge, SbbCardButton, SbbCardLink] as const;

--- a/src/angular/chip/chip.module.ts
+++ b/src/angular/chip/chip.module.ts
@@ -1,4 +1,4 @@
 import { SbbChip } from './chip/chip';
 import { SbbChipGroup } from './chip-group/chip-group';
 
-export const SbbChipModule = [SbbChip, SbbChipGroup];
+export const SbbChipModule = [SbbChip, SbbChipGroup] as const;

--- a/src/angular/datepicker/datepicker.module.ts
+++ b/src/angular/datepicker/datepicker.module.ts
@@ -8,4 +8,4 @@ export const SbbDatepickerModule = [
   SbbDatepickerNextDay,
   SbbDatepickerPreviousDay,
   SbbDatepickerToggle,
-];
+] as const;

--- a/src/angular/dialog/dialog.module.ts
+++ b/src/angular/dialog/dialog.module.ts
@@ -10,4 +10,4 @@ export const SbbDialogModule = [
   SbbDialogCloseButton,
   SbbDialogContent,
   SbbDialogTitle,
-];
+] as const;

--- a/src/angular/expansion-panel/expansion-panel.module.ts
+++ b/src/angular/expansion-panel/expansion-panel.module.ts
@@ -6,4 +6,4 @@ export const SbbExpansionPanelModule = [
   SbbExpansionPanel,
   SbbExpansionPanelContent,
   SbbExpansionPanelHeader,
-];
+] as const;

--- a/src/angular/flip-card/flip-card.module.ts
+++ b/src/angular/flip-card/flip-card.module.ts
@@ -2,4 +2,4 @@ import { SbbFlipCard } from './flip-card/flip-card';
 import { SbbFlipCardDetails } from './flip-card-details/flip-card-details';
 import { SbbFlipCardSummary } from './flip-card-summary/flip-card-summary';
 
-export const SbbFlipCardModule = [SbbFlipCard, SbbFlipCardDetails, SbbFlipCardSummary];
+export const SbbFlipCardModule = [SbbFlipCard, SbbFlipCardDetails, SbbFlipCardSummary] as const;

--- a/src/angular/form-field/form-field.module.ts
+++ b/src/angular/form-field/form-field.module.ts
@@ -1,4 +1,4 @@
 import { SbbFormField } from './form-field/form-field';
 import { SbbFormFieldClear } from './form-field-clear/form-field-clear';
 
-export const SbbFormFieldModule = [SbbFormField, SbbFormFieldClear];
+export const SbbFormFieldModule = [SbbFormField, SbbFormFieldClear] as const;

--- a/src/angular/header/header.module.ts
+++ b/src/angular/header/header.module.ts
@@ -3,4 +3,9 @@ import { SbbHeaderButton } from './header-button/header-button';
 import { SbbHeaderEnvironment } from './header-environment/header-environment';
 import { SbbHeaderLink } from './header-link/header-link';
 
-export const SbbHeaderModule = [SbbHeader, SbbHeaderButton, SbbHeaderEnvironment, SbbHeaderLink];
+export const SbbHeaderModule = [
+  SbbHeader,
+  SbbHeaderButton,
+  SbbHeaderEnvironment,
+  SbbHeaderLink,
+] as const;

--- a/src/angular/menu/menu.module.ts
+++ b/src/angular/menu/menu.module.ts
@@ -2,4 +2,4 @@ import { SbbMenu } from './menu/menu';
 import { SbbMenuButton } from './menu-button/menu-button';
 import { SbbMenuLink } from './menu-link/menu-link';
 
-export const SbbMenuModule = [SbbMenu, SbbMenuButton, SbbMenuLink];
+export const SbbMenuModule = [SbbMenu, SbbMenuButton, SbbMenuLink] as const;

--- a/src/angular/navigation/navigation.module.ts
+++ b/src/angular/navigation/navigation.module.ts
@@ -12,4 +12,4 @@ export const SbbNavigationModule = [
   SbbNavigationList,
   SbbNavigationMarker,
   SbbNavigationSection,
-];
+] as const;

--- a/src/angular/option/option.module.ts
+++ b/src/angular/option/option.module.ts
@@ -2,4 +2,4 @@ import { SbbOptGroup } from './optgroup/optgroup';
 import { SbbOption } from './option/option';
 import { SbbOptionHint } from './option-hint/option-hint';
 
-export const SbbOptionModule = [SbbOptGroup, SbbOption, SbbOptionHint];
+export const SbbOptionModule = [SbbOptGroup, SbbOption, SbbOptionHint] as const;

--- a/src/angular/popover/popover.module.ts
+++ b/src/angular/popover/popover.module.ts
@@ -1,4 +1,4 @@
 import { SbbPopover } from './popover/popover';
 import { SbbPopoverTrigger } from './popover-trigger/popover-trigger';
 
-export const SbbPopoverModule = [SbbPopover, SbbPopoverTrigger];
+export const SbbPopoverModule = [SbbPopover, SbbPopoverTrigger] as const;

--- a/src/angular/select/select.module.ts
+++ b/src/angular/select/select.module.ts
@@ -2,4 +2,4 @@ import { SbbOptionModule } from '@sbb-esta/lyne-angular/option';
 
 import { SbbSelect } from './select';
 
-export const SbbSelectModule = [SbbSelect, SbbOptionModule];
+export const SbbSelectModule = [SbbSelect, SbbOptionModule] as const;

--- a/src/angular/sidebar/sidebar.module.ts
+++ b/src/angular/sidebar/sidebar.module.ts
@@ -20,4 +20,4 @@ export const SbbSidebarModule = [
   SbbSidebarContainer,
   SbbSidebarContent,
   SbbSidebarTitle,
-];
+] as const;

--- a/src/angular/stepper/stepper.module.ts
+++ b/src/angular/stepper/stepper.module.ts
@@ -2,4 +2,4 @@ import { SbbStep } from './step/step';
 import { SbbStepLabel } from './step-label/step-label';
 import { SbbStepper } from './stepper/stepper';
 
-export const SbbStepperModule = [SbbStep, SbbStepLabel, SbbStepper];
+export const SbbStepperModule = [SbbStep, SbbStepLabel, SbbStepper] as const;

--- a/src/angular/table/table.module.ts
+++ b/src/angular/table/table.module.ts
@@ -51,4 +51,4 @@ export const SbbTableModule = [
   // Sort
   SbbSort,
   SbbSortHeader,
-];
+] as const;

--- a/src/angular/tabs/tabs.module.ts
+++ b/src/angular/tabs/tabs.module.ts
@@ -2,4 +2,4 @@ import { SbbTab } from './tab/tab';
 import { SbbTabGroup } from './tab-group/tab-group';
 import { SbbTabLabel } from './tab-label/tab-label';
 
-export const SbbTabsModule = [SbbTab, SbbTabGroup, SbbTabLabel];
+export const SbbTabsModule = [SbbTab, SbbTabGroup, SbbTabLabel] as const;

--- a/src/angular/tag/tag.module.ts
+++ b/src/angular/tag/tag.module.ts
@@ -1,4 +1,4 @@
 import { SbbTag } from './tag/tag';
 import { SbbTagGroup } from './tag-group/tag-group';
 
-export const SbbTagModule = [SbbTag, SbbTagGroup];
+export const SbbTagModule = [SbbTag, SbbTagGroup] as const;

--- a/src/angular/toggle/toggle.module.ts
+++ b/src/angular/toggle/toggle.module.ts
@@ -1,4 +1,4 @@
 import { SbbToggle } from './toggle/toggle';
 import { SbbToggleOption } from './toggle-option/toggle-option';
 
-export const SbbToggleModule = [SbbToggle, SbbToggleOption];
+export const SbbToggleModule = [SbbToggle, SbbToggleOption] as const;

--- a/src/angular/train/train.module.ts
+++ b/src/angular/train/train.module.ts
@@ -3,4 +3,9 @@ import { SbbTrainBlockedPassage } from './train-blocked-passage/train-blocked-pa
 import { SbbTrainFormation } from './train-formation/train-formation';
 import { SbbTrainWagon } from './train-wagon/train-wagon';
 
-export const SbbTrainModule = [SbbTrain, SbbTrainBlockedPassage, SbbTrainFormation, SbbTrainWagon];
+export const SbbTrainModule = [
+  SbbTrain,
+  SbbTrainBlockedPassage,
+  SbbTrainFormation,
+  SbbTrainWagon,
+] as const;

--- a/tools/eslint/angular-generator-rule.ts
+++ b/tools/eslint/angular-generator-rule.ts
@@ -165,7 +165,7 @@ const generateStructure = (pkg: Package, projectPath: string) => {
             }
 
             // Read the existing module array and alphabetically add the new class
-            const exportedModulesRegex = /export const (Sbb\w+Module) = \[(.*?)\];/s;
+            const exportedModulesRegex = /export const (Sbb\w+Module) = \[(.*?)\] as const;/s;
             const exportedDeclarationsMatch = angularModuleContent.match(exportedModulesRegex);
 
             if (exportedDeclarationsMatch) {
@@ -180,7 +180,7 @@ const generateStructure = (pkg: Package, projectPath: string) => {
                 exportedDeclarations.sort();
                 angularModuleContent = angularModuleContent.replace(
                   exportedModulesRegex,
-                  `export const ${exportModuleName} = [\n  ${exportedDeclarations.join(',\n  ')},\n];\n`,
+                  `export const ${exportModuleName} = [\n  ${exportedDeclarations.join(',\n  ')},\n] as const;\n`,
                 );
               }
             }


### PR DESCRIPTION
This addresses a bug where the Angular compiler does not understand component arrays without `as const`.