### PR TITLE
fix: exclude root's index.ts from hasCommonModule logic

### DIFF
--- a/tools/eslint/angular-generator-rule.ts
+++ b/tools/eslint/angular-generator-rule.ts
@@ -101,7 +101,7 @@ const generateStructure = (pkg: Package, projectPath: string) => {
 
         const indexPath = join(directoryPath, 'index.ts');
         const commonIndexPath = join(directoryPath, '..', 'index.ts');
-        // src/angular has his own index.ts, so it has to be excluded, otherwise all modules are treated as common
+        // the root folder has his own index.ts, so it has to be excluded, otherwise all modules are treated as common
         const hasCommonModule =
           existsSync(commonIndexPath) && projectPath !== join(directoryPath, '..');
         const ngPackagePath = join(directoryPath, 'ng-package.json');

--- a/tools/eslint/angular-generator-rule.ts
+++ b/tools/eslint/angular-generator-rule.ts
@@ -101,7 +101,9 @@ const generateStructure = (pkg: Package, projectPath: string) => {
 
         const indexPath = join(directoryPath, 'index.ts');
         const commonIndexPath = join(directoryPath, '..', 'index.ts');
-        const hasCommonModule = existsSync(commonIndexPath);
+        // src/angular has his own index.ts, so it has to be excluded, otherwise all modules are treated as common
+        const hasCommonModule =
+          existsSync(commonIndexPath) && projectPath !== join(directoryPath, '..');
         const ngPackagePath = join(directoryPath, 'ng-package.json');
 
         // Only add ng-package.json and index.ts if the module is not already in the common index


### PR DESCRIPTION
When the `lint` command is launched on a new component, a check on the presence of an `index.ts` file in the parent folder is triggered; if this is true, then the module is a common one (eg. breadcrumb, which contains both breadcrumb and breadcrumb-group).

However, for a non-common module, the check returns true, due to the presence of an `index.ts` in the root folder, breaking the file generation logic.
