### PR TITLE
docs: avoid 'EXPORTED_DECLARATIONS' clash on compodoc

### DIFF
--- a/scripts/migrate-modules.mts
+++ b/scripts/migrate-modules.mts
@@ -166,13 +166,17 @@ function writeAngularModule(
   const classNames = classExports.map((e) => e.name);
 
   const sbbModuleName = `Sbb${moduleName}Module`;
+  const exportedDeclaration = `SBB_${basename(moduleRoot).replaceAll('-', '_').toUpperCase()}_EXPORTED_DECLARATIONS`;
   const content = `
 import { NgModule } from '@angular/core';
+
 ${importLines.join('\n')}
-const EXPORTED_DECLARATIONS = [${classNames.join(', ')}];
+
+const ${exportedDeclaration} = [${classNames.join(', ')}];
+
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS
+  imports: ${exportedDeclaration},
+  exports: ${exportedDeclaration}
 })
 export class ${sbbModuleName} {}
 `;

--- a/src/angular-experimental/seat-reservation/seat-reservation.module.ts
+++ b/src/angular-experimental/seat-reservation/seat-reservation.module.ts
@@ -8,7 +8,7 @@ import { SbbSeatReservationNavigationServices } from './seat-reservation-navigat
 import { SbbSeatReservationPlaceControl } from './seat-reservation-place-control/seat-reservation-place-control';
 import { SbbSeatReservationScoped } from './seat-reservation-scoped/seat-reservation-scoped';
 
-const EXPORTED_DECLARATIONS = [
+const SBB_SEAT_RESERVATION_EXPORTED_DECLARATIONS = [
   SbbSeatReservation,
   SbbSeatReservationArea,
   SbbSeatReservationGraphic,
@@ -19,7 +19,7 @@ const EXPORTED_DECLARATIONS = [
 ];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_SEAT_RESERVATION_EXPORTED_DECLARATIONS,
+  exports: SBB_SEAT_RESERVATION_EXPORTED_DECLARATIONS,
 })
 export class SbbSeatReservationModule {}

--- a/src/angular/accordion/accordion.module.ts
+++ b/src/angular/accordion/accordion.module.ts
@@ -3,10 +3,10 @@ import { SbbExpansionPanelModule } from '@sbb-esta/lyne-angular/expansion-panel'
 
 import { SbbAccordion } from './accordion';
 
-const EXPORTED_DECLARATIONS = [SbbAccordion, SbbExpansionPanelModule];
+const SBB_ACCORDION_EXPORTED_DECLARATIONS = [SbbAccordion, SbbExpansionPanelModule];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_ACCORDION_EXPORTED_DECLARATIONS,
+  exports: SBB_ACCORDION_EXPORTED_DECLARATIONS,
 })
 export class SbbAccordionModule {}

--- a/src/angular/alert/alert.module.ts
+++ b/src/angular/alert/alert.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { SbbAlert } from './alert/alert';
 import { SbbAlertGroup } from './alert-group/alert-group';
 
-const EXPORTED_DECLARATIONS = [SbbAlert, SbbAlertGroup];
+const SBB_ALERT_EXPORTED_DECLARATIONS = [SbbAlert, SbbAlertGroup];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_ALERT_EXPORTED_DECLARATIONS,
+  exports: SBB_ALERT_EXPORTED_DECLARATIONS,
 })
 export class SbbAlertModule {}

--- a/src/angular/autocomplete-grid/autocomplete-grid.module.ts
+++ b/src/angular/autocomplete-grid/autocomplete-grid.module.ts
@@ -8,7 +8,7 @@ import { SbbAutocompleteGridOptgroup } from './autocomplete-grid-optgroup/autoco
 import { SbbAutocompleteGridOption } from './autocomplete-grid-option/autocomplete-grid-option';
 import { SbbAutocompleteGridRow } from './autocomplete-grid-row/autocomplete-grid-row';
 
-const EXPORTED_DECLARATIONS = [
+const SBB_AUTOCOMPLETE_GRID_EXPORTED_DECLARATIONS = [
   SbbAutocompleteTrigger,
   SbbAutocompleteGrid,
   SbbAutocompleteGridButton,
@@ -19,7 +19,7 @@ const EXPORTED_DECLARATIONS = [
 ];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_AUTOCOMPLETE_GRID_EXPORTED_DECLARATIONS,
+  exports: SBB_AUTOCOMPLETE_GRID_EXPORTED_DECLARATIONS,
 })
 export class SbbAutocompleteGridModule {}

--- a/src/angular/autocomplete/autocomplete.module.ts
+++ b/src/angular/autocomplete/autocomplete.module.ts
@@ -4,10 +4,14 @@ import { SbbOptionModule } from '@sbb-esta/lyne-angular/option';
 import { SbbAutocomplete } from './autocomplete';
 import { SbbAutocompleteTrigger } from './autocomplete-trigger';
 
-const EXPORTED_DECLARATIONS = [SbbAutocompleteTrigger, SbbAutocomplete, SbbOptionModule];
+const SBB_AUTOCOMPLETE_EXPORTED_DECLARATIONS = [
+  SbbAutocompleteTrigger,
+  SbbAutocomplete,
+  SbbOptionModule,
+];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_AUTOCOMPLETE_EXPORTED_DECLARATIONS,
+  exports: SBB_AUTOCOMPLETE_EXPORTED_DECLARATIONS,
 })
 export class SbbAutocompleteModule {}

--- a/src/angular/breadcrumb/breadcrumb.module.ts
+++ b/src/angular/breadcrumb/breadcrumb.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { SbbBreadcrumb } from './breadcrumb/breadcrumb';
 import { SbbBreadcrumbGroup } from './breadcrumb-group/breadcrumb-group';
 
-const EXPORTED_DECLARATIONS = [SbbBreadcrumb, SbbBreadcrumbGroup];
+const SBB_BREADCRUMB_EXPORTED_DECLARATIONS = [SbbBreadcrumb, SbbBreadcrumbGroup];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_BREADCRUMB_EXPORTED_DECLARATIONS,
+  exports: SBB_BREADCRUMB_EXPORTED_DECLARATIONS,
 })
 export class SbbBreadcrumbModule {}

--- a/src/angular/card/card.module.ts
+++ b/src/angular/card/card.module.ts
@@ -5,10 +5,10 @@ import { SbbCardBadge } from './card-badge/card-badge';
 import { SbbCardButton } from './card-button/card-button';
 import { SbbCardLink } from './card-link/card-link';
 
-const EXPORTED_DECLARATIONS = [SbbCard, SbbCardBadge, SbbCardButton, SbbCardLink];
+const SBB_CARD_EXPORTED_DECLARATIONS = [SbbCard, SbbCardBadge, SbbCardButton, SbbCardLink];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_CARD_EXPORTED_DECLARATIONS,
+  exports: SBB_CARD_EXPORTED_DECLARATIONS,
 })
 export class SbbCardModule {}

--- a/src/angular/carousel/carousel.module.ts
+++ b/src/angular/carousel/carousel.module.ts
@@ -4,10 +4,10 @@ import { SbbCarousel } from './carousel/carousel';
 import { SbbCarouselItem } from './carousel-item/carousel-item';
 import { SbbCarouselList } from './carousel-list/carousel-list';
 
-const EXPORTED_DECLARATIONS = [SbbCarousel, SbbCarouselItem, SbbCarouselList];
+const SBB_CAROUSEL_EXPORTED_DECLARATIONS = [SbbCarousel, SbbCarouselItem, SbbCarouselList];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_CAROUSEL_EXPORTED_DECLARATIONS,
+  exports: SBB_CAROUSEL_EXPORTED_DECLARATIONS,
 })
 export class SbbCarouselModule {}

--- a/src/angular/chip/chip.module.ts
+++ b/src/angular/chip/chip.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { SbbChip } from './chip/chip';
 import { SbbChipGroup } from './chip-group/chip-group';
 
-const EXPORTED_DECLARATIONS = [SbbChip, SbbChipGroup];
+const SBB_CHIP_EXPORTED_DECLARATIONS = [SbbChip, SbbChipGroup];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_CHIP_EXPORTED_DECLARATIONS,
+  exports: SBB_CHIP_EXPORTED_DECLARATIONS,
 })
 export class SbbChipModule {}

--- a/src/angular/datepicker/datepicker.module.ts
+++ b/src/angular/datepicker/datepicker.module.ts
@@ -5,7 +5,7 @@ import { SbbDatepickerNextDay } from './datepicker-next-day/datepicker-next-day'
 import { SbbDatepickerPreviousDay } from './datepicker-previous-day/datepicker-previous-day';
 import { SbbDatepickerToggle } from './datepicker-toggle/datepicker-toggle';
 
-const EXPORTED_DECLARATIONS = [
+const SBB_DATEPICKER_EXPORTED_DECLARATIONS = [
   SbbDatepicker,
   SbbDatepickerNextDay,
   SbbDatepickerPreviousDay,
@@ -13,7 +13,7 @@ const EXPORTED_DECLARATIONS = [
 ];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_DATEPICKER_EXPORTED_DECLARATIONS,
+  exports: SBB_DATEPICKER_EXPORTED_DECLARATIONS,
 })
 export class SbbDatepickerModule {}

--- a/src/angular/dialog/dialog.module.ts
+++ b/src/angular/dialog/dialog.module.ts
@@ -7,7 +7,7 @@ import { SbbDialogCloseButton } from './dialog-close-button/dialog-close-button'
 import { SbbDialogContent } from './dialog-content/dialog-content';
 import { SbbDialogTitle } from './dialog-title/dialog-title';
 
-const EXPORTED_DECLARATIONS = [
+const SBB_DIALOG_EXPORTED_DECLARATIONS = [
   SbbDialog,
   SbbDialogActions,
   SbbDialogCloseButton,
@@ -17,7 +17,7 @@ const EXPORTED_DECLARATIONS = [
 ];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_DIALOG_EXPORTED_DECLARATIONS,
+  exports: SBB_DIALOG_EXPORTED_DECLARATIONS,
 })
 export class SbbDialogModule {}

--- a/src/angular/expansion-panel/expansion-panel.module.ts
+++ b/src/angular/expansion-panel/expansion-panel.module.ts
@@ -4,14 +4,14 @@ import { SbbExpansionPanel } from './expansion-panel/expansion-panel';
 import { SbbExpansionPanelContent } from './expansion-panel-content/expansion-panel-content';
 import { SbbExpansionPanelHeader } from './expansion-panel-header/expansion-panel-header';
 
-const EXPORTED_DECLARATIONS = [
+const SBB_EXPANSION_PANEL_EXPORTED_DECLARATIONS = [
   SbbExpansionPanel,
   SbbExpansionPanelContent,
   SbbExpansionPanelHeader,
 ];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_EXPANSION_PANEL_EXPORTED_DECLARATIONS,
+  exports: SBB_EXPANSION_PANEL_EXPORTED_DECLARATIONS,
 })
 export class SbbExpansionPanelModule {}

--- a/src/angular/flip-card/flip-card.module.ts
+++ b/src/angular/flip-card/flip-card.module.ts
@@ -4,10 +4,10 @@ import { SbbFlipCard } from './flip-card/flip-card';
 import { SbbFlipCardDetails } from './flip-card-details/flip-card-details';
 import { SbbFlipCardSummary } from './flip-card-summary/flip-card-summary';
 
-const EXPORTED_DECLARATIONS = [SbbFlipCard, SbbFlipCardDetails, SbbFlipCardSummary];
+const SBB_FLIP_CARD_EXPORTED_DECLARATIONS = [SbbFlipCard, SbbFlipCardDetails, SbbFlipCardSummary];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_FLIP_CARD_EXPORTED_DECLARATIONS,
+  exports: SBB_FLIP_CARD_EXPORTED_DECLARATIONS,
 })
 export class SbbFlipCardModule {}

--- a/src/angular/form-field/form-field.module.ts
+++ b/src/angular/form-field/form-field.module.ts
@@ -4,10 +4,10 @@ import { SbbFormError } from '@sbb-esta/lyne-angular/form-error';
 import { SbbFormField } from './form-field/form-field';
 import { SbbFormFieldClear } from './form-field-clear/form-field-clear';
 
-const EXPORTED_DECLARATIONS = [SbbFormField, SbbFormFieldClear, SbbFormError];
+const SBB_FORM_FIELD_EXPORTED_DECLARATIONS = [SbbFormField, SbbFormFieldClear, SbbFormError];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_FORM_FIELD_EXPORTED_DECLARATIONS,
+  exports: SBB_FORM_FIELD_EXPORTED_DECLARATIONS,
 })
 export class SbbFormFieldModule {}

--- a/src/angular/header/header.module.ts
+++ b/src/angular/header/header.module.ts
@@ -5,10 +5,15 @@ import { SbbHeaderButton } from './header-button/header-button';
 import { SbbHeaderEnvironment } from './header-environment/header-environment';
 import { SbbHeaderLink } from './header-link/header-link';
 
-const EXPORTED_DECLARATIONS = [SbbHeader, SbbHeaderButton, SbbHeaderEnvironment, SbbHeaderLink];
+const SBB_HEADER_EXPORTED_DECLARATIONS = [
+  SbbHeader,
+  SbbHeaderButton,
+  SbbHeaderEnvironment,
+  SbbHeaderLink,
+];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_HEADER_EXPORTED_DECLARATIONS,
+  exports: SBB_HEADER_EXPORTED_DECLARATIONS,
 })
 export class SbbHeaderModule {}

--- a/src/angular/menu/menu.module.ts
+++ b/src/angular/menu/menu.module.ts
@@ -4,10 +4,10 @@ import { SbbMenu } from './menu/menu';
 import { SbbMenuButton } from './menu-button/menu-button';
 import { SbbMenuLink } from './menu-link/menu-link';
 
-const EXPORTED_DECLARATIONS = [SbbMenu, SbbMenuButton, SbbMenuLink];
+const SBB_MENU_EXPORTED_DECLARATIONS = [SbbMenu, SbbMenuButton, SbbMenuLink];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_MENU_EXPORTED_DECLARATIONS,
+  exports: SBB_MENU_EXPORTED_DECLARATIONS,
 })
 export class SbbMenuModule {}

--- a/src/angular/mini-calendar/mini-calendar.module.ts
+++ b/src/angular/mini-calendar/mini-calendar.module.ts
@@ -4,9 +4,13 @@ import { SbbMiniCalendar } from './mini-calendar/mini-calendar';
 import { SbbMiniCalendarDay } from './mini-calendar-day/mini-calendar-day';
 import { SbbMiniCalendarMonth } from './mini-calendar-month/mini-calendar-month';
 
-const EXPORTED_DECLARATIONS = [SbbMiniCalendar, SbbMiniCalendarMonth, SbbMiniCalendarDay];
+const SBB_MINI_CALENDAR_EXPORTED_DECLARATIONS = [
+  SbbMiniCalendar,
+  SbbMiniCalendarMonth,
+  SbbMiniCalendarDay,
+];
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_MINI_CALENDAR_EXPORTED_DECLARATIONS,
+  exports: SBB_MINI_CALENDAR_EXPORTED_DECLARATIONS,
 })
 export class SbbMiniCalendarModule {}

--- a/src/angular/navigation/navigation.module.ts
+++ b/src/angular/navigation/navigation.module.ts
@@ -7,7 +7,7 @@ import { SbbNavigationList } from './navigation-list/navigation-list';
 import { SbbNavigationMarker } from './navigation-marker/navigation-marker';
 import { SbbNavigationSection } from './navigation-section/navigation-section';
 
-const EXPORTED_DECLARATIONS = [
+const SBB_NAVIGATION_EXPORTED_DECLARATIONS = [
   SbbNavigation,
   SbbNavigationButton,
   SbbNavigationLink,
@@ -17,7 +17,7 @@ const EXPORTED_DECLARATIONS = [
 ];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_NAVIGATION_EXPORTED_DECLARATIONS,
+  exports: SBB_NAVIGATION_EXPORTED_DECLARATIONS,
 })
 export class SbbNavigationModule {}

--- a/src/angular/option/option.module.ts
+++ b/src/angular/option/option.module.ts
@@ -4,10 +4,10 @@ import { SbbOptGroup } from './optgroup/optgroup';
 import { SbbOption } from './option/option';
 import { SbbOptionHint } from './option-hint/option-hint';
 
-const EXPORTED_DECLARATIONS = [SbbOptGroup, SbbOption, SbbOptionHint];
+const SBB_OPTION_EXPORTED_DECLARATIONS = [SbbOptGroup, SbbOption, SbbOptionHint];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_OPTION_EXPORTED_DECLARATIONS,
+  exports: SBB_OPTION_EXPORTED_DECLARATIONS,
 })
 export class SbbOptionModule {}

--- a/src/angular/overlay/overlay.module.ts
+++ b/src/angular/overlay/overlay.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { SbbOverlay } from './overlay';
 import { SbbOverlayContainer } from './overlay-container';
 
-const EXPORTED_DECLARATIONS = [SbbOverlay, SbbOverlayContainer];
+const SBB_OVERLAY_EXPORTED_DECLARATIONS = [SbbOverlay, SbbOverlayContainer];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_OVERLAY_EXPORTED_DECLARATIONS,
+  exports: SBB_OVERLAY_EXPORTED_DECLARATIONS,
 })
 export class SbbOverlayModule {}

--- a/src/angular/popover/popover.module.ts
+++ b/src/angular/popover/popover.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { SbbPopover } from './popover/popover';
 import { SbbPopoverTrigger } from './popover-trigger/popover-trigger';
 
-const EXPORTED_DECLARATIONS = [SbbPopover, SbbPopoverTrigger];
+const SBB_POPOVER_EXPORTED_DECLARATIONS = [SbbPopover, SbbPopoverTrigger];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_POPOVER_EXPORTED_DECLARATIONS,
+  exports: SBB_POPOVER_EXPORTED_DECLARATIONS,
 })
 export class SbbPopoverModule {}

--- a/src/angular/select/select.module.ts
+++ b/src/angular/select/select.module.ts
@@ -3,10 +3,10 @@ import { SbbOptionModule } from '@sbb-esta/lyne-angular/option';
 
 import { SbbSelect } from './select';
 
-const EXPORTED_DECLARATIONS = [SbbSelect, SbbOptionModule];
+const SBB_SELECT_EXPORTED_DECLARATIONS = [SbbSelect, SbbOptionModule];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_SELECT_EXPORTED_DECLARATIONS,
+  exports: SBB_SELECT_EXPORTED_DECLARATIONS,
 })
 export class SbbSelectModule {}

--- a/src/angular/sidebar/sidebar.module.ts
+++ b/src/angular/sidebar/sidebar.module.ts
@@ -11,7 +11,7 @@ import { SbbSidebarContainer } from './sidebar-container/sidebar-container';
 import { SbbSidebarContent } from './sidebar-content/sidebar-content';
 import { SbbSidebarTitle } from './sidebar-title/sidebar-title';
 
-const EXPORTED_DECLARATIONS = [
+const SBB_SIDEBAR_EXPORTED_DECLARATIONS = [
   SbbIconSidebar,
   SbbIconSidebarButton,
   SbbIconSidebarContainer,
@@ -25,7 +25,7 @@ const EXPORTED_DECLARATIONS = [
 ];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_SIDEBAR_EXPORTED_DECLARATIONS,
+  exports: SBB_SIDEBAR_EXPORTED_DECLARATIONS,
 })
 export class SbbSidebarModule {}

--- a/src/angular/stepper/stepper.module.ts
+++ b/src/angular/stepper/stepper.module.ts
@@ -4,10 +4,10 @@ import { SbbStep } from './step/step';
 import { SbbStepLabel } from './step-label/step-label';
 import { SbbStepper } from './stepper/stepper';
 
-const EXPORTED_DECLARATIONS = [SbbStep, SbbStepLabel, SbbStepper];
+const SBB_STEPPER_EXPORTED_DECLARATIONS = [SbbStep, SbbStepLabel, SbbStepper];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_STEPPER_EXPORTED_DECLARATIONS,
+  exports: SBB_STEPPER_EXPORTED_DECLARATIONS,
 })
 export class SbbStepperModule {}

--- a/src/angular/table/table.module.ts
+++ b/src/angular/table/table.module.ts
@@ -23,7 +23,7 @@ import { SbbRecycleRows, SbbTable } from './table/table';
 import { SbbTextColumn } from './table/text-column';
 import { SbbTableWrapper } from './table-wrapper/table-wrapper';
 
-const EXPORTED_DECLARATIONS = [
+const SBB_TABLE_EXPORTED_DECLARATIONS = [
   // Table
   SbbTable,
   SbbRecycleRows,
@@ -56,7 +56,7 @@ const EXPORTED_DECLARATIONS = [
 ];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_TABLE_EXPORTED_DECLARATIONS,
+  exports: SBB_TABLE_EXPORTED_DECLARATIONS,
 })
 export class SbbTableModule {}

--- a/src/angular/tabs/tabs.module.ts
+++ b/src/angular/tabs/tabs.module.ts
@@ -5,10 +5,10 @@ import { SbbTabContent } from './tab/tab-content';
 import { SbbTabGroup } from './tab-group/tab-group';
 import { SbbTabLabel } from './tab-label/tab-label';
 
-const EXPORTED_DECLARATIONS = [SbbTab, SbbTabContent, SbbTabGroup, SbbTabLabel];
+const SBB_TAB_EXPORTED_DECLARATIONS = [SbbTab, SbbTabContent, SbbTabGroup, SbbTabLabel];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_TAB_EXPORTED_DECLARATIONS,
+  exports: SBB_TAB_EXPORTED_DECLARATIONS,
 })
 export class SbbTabsModule {}

--- a/src/angular/tag/tag.module.ts
+++ b/src/angular/tag/tag.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { SbbTag } from './tag/tag';
 import { SbbTagGroup } from './tag-group/tag-group';
 
-const EXPORTED_DECLARATIONS = [SbbTag, SbbTagGroup];
+const SBB_TAG_EXPORTED_DECLARATIONS = [SbbTag, SbbTagGroup];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_TAG_EXPORTED_DECLARATIONS,
+  exports: SBB_TAG_EXPORTED_DECLARATIONS,
 })
 export class SbbTagModule {}

--- a/src/angular/timetable-form/timetable-form.module.ts
+++ b/src/angular/timetable-form/timetable-form.module.ts
@@ -5,7 +5,7 @@ import { SbbTimetableFormDetails } from './timetable-form-details/timetable-form
 import { SbbTimetableFormField } from './timetable-form-field/timetable-form-field';
 import { SbbTimetableFormSwapButton } from './timetable-form-swap-button/timetable-form-swap-button';
 
-const EXPORTED_DECLARATIONS = [
+const SBB_TIMETABLE_FORM_EXPORTED_DECLARATIONS = [
   SbbTimetableForm,
   SbbTimetableFormDetails,
   SbbTimetableFormField,
@@ -13,7 +13,7 @@ const EXPORTED_DECLARATIONS = [
 ];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_TIMETABLE_FORM_EXPORTED_DECLARATIONS,
+  exports: SBB_TIMETABLE_FORM_EXPORTED_DECLARATIONS,
 })
 export class SbbTimetableFormModule {}

--- a/src/angular/toast/toast.module.ts
+++ b/src/angular/toast/toast.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { SbbToast } from './toast';
 import { SbbToastContainer } from './toast-container';
 
-const EXPORTED_DECLARATIONS = [SbbToast, SbbToastContainer];
+const SBB_TOAST_EXPORTED_DECLARATIONS = [SbbToast, SbbToastContainer];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_TOAST_EXPORTED_DECLARATIONS,
+  exports: SBB_TOAST_EXPORTED_DECLARATIONS,
 })
 export class SbbToastModule {}

--- a/src/angular/toggle/toggle.module.ts
+++ b/src/angular/toggle/toggle.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { SbbToggle } from './toggle/toggle';
 import { SbbToggleOption } from './toggle-option/toggle-option';
 
-const EXPORTED_DECLARATIONS = [SbbToggle, SbbToggleOption];
+const SBB_TOGGLE_EXPORTED_DECLARATIONS = [SbbToggle, SbbToggleOption];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_TOGGLE_EXPORTED_DECLARATIONS,
+  exports: SBB_TOGGLE_EXPORTED_DECLARATIONS,
 })
 export class SbbToggleModule {}

--- a/src/angular/tooltip/tooltip.module.ts
+++ b/src/angular/tooltip/tooltip.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { SbbTooltip } from './tooltip';
 import { SbbTooltipDirective } from './tooltip-directives';
 
-const EXPORTED_DECLARATIONS = [SbbTooltip, SbbTooltipDirective];
+const SBB_TOOLTIP_EXPORTED_DECLARATIONS = [SbbTooltip, SbbTooltipDirective];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_TOOLTIP_EXPORTED_DECLARATIONS,
+  exports: SBB_TOOLTIP_EXPORTED_DECLARATIONS,
 })
 export class SbbTooltipModule {}

--- a/src/angular/train/train.module.ts
+++ b/src/angular/train/train.module.ts
@@ -5,10 +5,15 @@ import { SbbTrainBlockedPassage } from './train-blocked-passage/train-blocked-pa
 import { SbbTrainFormation } from './train-formation/train-formation';
 import { SbbTrainWagon } from './train-wagon/train-wagon';
 
-const EXPORTED_DECLARATIONS = [SbbTrain, SbbTrainBlockedPassage, SbbTrainFormation, SbbTrainWagon];
+const SBB_TRAIN_EXPORTED_DECLARATIONS = [
+  SbbTrain,
+  SbbTrainBlockedPassage,
+  SbbTrainFormation,
+  SbbTrainWagon,
+];
 
 @NgModule({
-  imports: EXPORTED_DECLARATIONS,
-  exports: EXPORTED_DECLARATIONS,
+  imports: SBB_TRAIN_EXPORTED_DECLARATIONS,
+  exports: SBB_TRAIN_EXPORTED_DECLARATIONS,
 })
 export class SbbTrainModule {}


### PR DESCRIPTION
When compodoc is runned, the module section is flawed: each module has as import / export the elements of the first created module (the SbbAlertModule in the attached image).
The issue can be verified by checking the documentation.json file in src/showcase/.storybook and looking for modules -> children -> type import / export.
Adding the module name in each module `EXPORTED_DECLARATIONS` fixes the issues.

<img width="296" height="1039" alt="immagine (1)" src="https://github.com/user-attachments/assets/1675b890-bcf6-463c-9c9e-e197ebbe1de6" />

