### PR TITLE
feat: add date adapter provider functions

### DIFF
--- a/src/angular/core/datetime/provide-native-date-adapter.ts
+++ b/src/angular/core/datetime/provide-native-date-adapter.ts
@@ -1,0 +1,17 @@
+import type { Provider } from '@angular/core';
+import { DateAdapter, NativeDateAdapter } from '@sbb-esta/lyne-elements/core/datetime.js';
+
+/**
+ * Provides the native date adapter for Angular's dependency injection.
+ * IMPORTANT: This is not currently used for resolving the date adapter in components
+ * that use a date adapter. We are currently investigating on how we can achieve this
+ * without breaking expectations.
+ */
+export function provideNativeDateAdapter(): Provider[] {
+  return [
+    {
+      provide: DateAdapter,
+      useClass: NativeDateAdapter,
+    },
+  ];
+}

--- a/src/angular/core/datetime/provide-temporal-date-adapter.ts
+++ b/src/angular/core/datetime/provide-temporal-date-adapter.ts
@@ -1,0 +1,17 @@
+import type { Provider } from '@angular/core';
+import { DateAdapter, TemporalDateAdapter } from '@sbb-esta/lyne-elements/core/datetime.js';
+
+/**
+ * Provides the Temporal date adapter for Angular's dependency injection.
+ * IMPORTANT: This is not currently used for resolving the date adapter in components
+ * that use a date adapter. We are currently investigating on how we can achieve this
+ * without breaking expectations.
+ */
+export function provideTemporalDateAdapter(): Provider[] {
+  return [
+    {
+      provide: DateAdapter,
+      useClass: TemporalDateAdapter,
+    },
+  ];
+}

--- a/src/angular/core/index.ts
+++ b/src/angular/core/index.ts
@@ -1,3 +1,5 @@
+export * from './datetime/provide-native-date-adapter';
+export * from './datetime/provide-temporal-date-adapter';
 export * from './attribute-transform';
 export * from './control-value-accessor-mixin';
 export * from './deferred-animation';


### PR DESCRIPTION
Currently this only implements registering the date adapters to the Angular dependency injection functionality.
It does not yet set the date adapter for the relevant components.