### PR TITLE
fix(overlay-services): fix closeAll functionality

### DIFF
--- a/src/angular/core/overlay/overlay-base.ts
+++ b/src/angular/core/overlay/overlay-base.ts
@@ -228,7 +228,8 @@ export abstract class SbbOverlayBaseService<
    * Closes all currently-open overlays.
    */
   closeAll(): void {
-    this.openOverlays.map((ref: R) => ref.close());
+    // We have to copy the array first as the array is mutated during the iteration.
+    this.openOverlays.slice().forEach((ref: R) => ref.close());
   }
 
   #getAfterAllClosed(): Subject<void> {

--- a/src/angular/dialog/dialog/dialog.spec.ts
+++ b/src/angular/dialog/dialog/dialog.spec.ts
@@ -3,7 +3,6 @@ import { Location } from '@angular/common';
 import { SpyLocation } from '@angular/common/testing';
 import {
   Component,
-  DestroyRef,
   Directive,
   inject,
   Injector,
@@ -43,7 +42,7 @@ describe('sbb-dialog', () => {
     beforeEach(async () => {
       await TestBed.configureTestingModule({
         imports: [ServiceTestComponent, SbbDummyComponent, TestComponent],
-        providers: [{ provide: Location, useClass: SpyLocation }, SbbDialogService, DestroyRef],
+        providers: [{ provide: Location, useClass: SpyLocation }, SbbDialogService],
       }).compileComponents();
 
       fixture = TestBed.createComponent(ServiceTestComponent);
@@ -173,6 +172,30 @@ describe('sbb-dialog', () => {
       await fixture.whenRenderingDone();
 
       expect(overlayContainerElement.children.length).toBe(1);
+    });
+
+    it('should close all when calling closeAll', async () => {
+      const afterCloseSpy1 = vi.fn();
+      const afterCloseSpy2 = vi.fn();
+
+      const ref1 = service.open(SbbDummyComponent);
+      const ref2 = service.open(SbbDummyComponent);
+
+      ref1.afterClosed.subscribe(afterCloseSpy1);
+      ref2.afterClosed.subscribe(afterCloseSpy2);
+
+      expect(overlayContainerElement.children.length).toBe(2);
+      expect(
+        Array.from(overlayContainerElement.querySelectorAll('sbb-dialog')).every(
+          (dialog) => dialog.isOpen,
+        ),
+      ).toBe(true);
+
+      service.closeAll();
+
+      expect(afterCloseSpy1).toHaveBeenCalled();
+      expect(afterCloseSpy2).toHaveBeenCalled();
+      expect(overlayContainerElement.children.length).toBe(0);
     });
   });
 });

--- a/src/angular/overlay/overlay.spec.ts
+++ b/src/angular/overlay/overlay.spec.ts
@@ -167,6 +167,30 @@ describe('sbb-overlay', () => {
 
       expect(overlayContainerElement.children.length).toBe(1);
     });
+
+    it('should close all when calling closeAll', async () => {
+      const afterCloseSpy1 = vi.fn();
+      const afterCloseSpy2 = vi.fn();
+
+      const ref1 = service.open(SbbDummyComponent);
+      const ref2 = service.open(SbbDummyComponent);
+
+      ref1.afterClosed.subscribe(afterCloseSpy1);
+      ref2.afterClosed.subscribe(afterCloseSpy2);
+
+      expect(overlayContainerElement.children.length).toBe(2);
+      expect(
+        Array.from(overlayContainerElement.querySelectorAll('sbb-overlay')).every(
+          (overlay) => overlay.isOpen,
+        ),
+      ).toBe(true);
+
+      service.closeAll();
+
+      expect(afterCloseSpy1).toHaveBeenCalled();
+      expect(afterCloseSpy2).toHaveBeenCalled();
+      expect(overlayContainerElement.children.length).toBe(0);
+    });
   });
 });
 

--- a/src/angular/toast/toast.spec.ts
+++ b/src/angular/toast/toast.spec.ts
@@ -175,6 +175,28 @@ describe('sbb-toast', () => {
       fixture.detectChanges();
       expect(spy).toHaveBeenCalled();
     });
+
+    it('should close all when calling closeAll', async () => {
+      const afterCloseSpy1 = vi.fn();
+
+      service.open(SbbDummyComponent);
+      // The first toast is closed, when the second one is opened
+      const ref1 = service.open(SbbDummyComponent);
+
+      ref1.afterClosed.subscribe(afterCloseSpy1);
+
+      expect(overlayContainerElement.children.length).toBe(1);
+      expect(
+        Array.from(overlayContainerElement.querySelectorAll('sbb-toast')).every(
+          (toast) => toast.isOpen,
+        ),
+      ).toBe(true);
+
+      service.closeAll();
+
+      expect(afterCloseSpy1).toHaveBeenCalled();
+      expect(overlayContainerElement.children.length).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
The `closeAll` call missed the last open overlay until this PR.