### PR TITLE
fix(overlay-services): weaken close event type

### DIFF
--- a/src/angular/dialog/dialog/dialog-service.ts
+++ b/src/angular/dialog/dialog/dialog-service.ts
@@ -16,7 +16,9 @@ export class SbbDialogService extends SbbOverlayBaseService<
   protected containerType = SbbDialogContainer;
   protected overlayRefConstructor = SbbDialogRef;
 
-  public override open<T = unknown, R = unknown>(
+  // TODO(breaking-change): The default type for R should be `unknown`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public override open<T = unknown, R = any>(
     componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
     config?: SbbOverlayConfig<SbbDialogContainer, SbbDialog>,
   ): SbbDialogRef<T, R> {

--- a/src/angular/overlay/overlay-service.ts
+++ b/src/angular/overlay/overlay-service.ts
@@ -16,7 +16,9 @@ export class SbbOverlayService extends SbbOverlayBaseService<
   protected containerType = SbbOverlayContainer;
   protected overlayRefConstructor = SbbOverlayRef;
 
-  public override open<T = unknown, R = unknown>(
+  // TODO(breaking-change): The default type for R should be `unknown`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public override open<T = unknown, R = any>(
     componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
     config?: SbbOverlayConfig<SbbOverlayContainer, SbbOverlay>,
   ): SbbOverlayRef<T, R> {


### PR DESCRIPTION
With #292 we introduced an unwanted breaking change. This commit weakens the type to any.