### PR TITLE
fix(select): sync late-bound string option values

### DIFF
--- a/src/angular/dialog/dialog/dialog.spec.ts
+++ b/src/angular/dialog/dialog/dialog.spec.ts
@@ -8,10 +8,13 @@ import {
   Injector,
   type TemplateRef,
   ViewChild,
+  viewChild,
   ViewContainerRef,
 } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { SBB_OVERLAY_DATA } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbSelect, SbbSelectModule } from '@sbb-esta/lyne-angular/select';
 
 import { SbbDialog } from './dialog';
 import { SbbDialogRef } from './dialog-ref';
@@ -41,7 +44,7 @@ describe('sbb-dialog', () => {
 
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        imports: [ServiceTestComponent, SbbDummyComponent, TestComponent],
+        imports: [ServiceTestComponent, SbbDialogSelectComponent, SbbDummyComponent, TestComponent],
         providers: [{ provide: Location, useClass: SpyLocation }, SbbDialogService],
       }).compileComponents();
 
@@ -197,6 +200,17 @@ describe('sbb-dialog', () => {
       expect(afterCloseSpy2).toHaveBeenCalled();
       expect(overlayContainerElement.children.length).toBe(0);
     });
+
+    it('should initialize bound string option values inside a dialog', async () => {
+      const ref = service.open(SbbDialogSelectComponent, {
+        viewContainerRef: component.childViewContainer,
+      });
+
+      await fixture.whenRenderingDone();
+
+      expect(ref.componentInstance?.select().value).toEqual('my-string-value');
+      expect(ref.componentInstance?.select().getDisplayValue()).toEqual('My string value');
+    });
   });
 });
 
@@ -244,6 +258,19 @@ class SbbDummyComponent {
   readonly data = inject<SampleData>(SBB_OVERLAY_DATA, { optional: true });
   readonly ref = inject(SbbDialogRef);
   readonly injector = inject(Injector);
+}
+
+@Component({
+  selector: 'sbb-dialog-select-component',
+  template: `<sbb-select [formControl]="control">
+    <sbb-option [value]="'other-value'">Other value</sbb-option>
+    <sbb-option [value]="'my-string-value'">My string value</sbb-option>
+  </sbb-select>`,
+  imports: [SbbSelectModule, ReactiveFormsModule],
+})
+class SbbDialogSelectComponent {
+  select = viewChild.required(SbbSelect<string>);
+  control = new FormControl('my-string-value');
 }
 
 export interface SampleData {

--- a/src/angular/option/option/option.ts
+++ b/src/angular/option/option/option.ts
@@ -2,6 +2,7 @@ import { Directive, ElementRef, inject, Input, NgZone, type OutputRef } from '@a
 import { outputFromObservable } from '@angular/core/rxjs-interop';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import type { SbbOptionElement } from '@sbb-esta/lyne-elements/option.js';
+import type { SbbSelectElement } from '@sbb-esta/lyne-elements/select.js';
 import { fromEvent } from 'rxjs';
 
 import '@sbb-esta/lyne-elements/option.js';
@@ -50,7 +51,27 @@ export class SbbOption<T = string> {
    */
   @Input()
   public set value(value: T) {
-    this.#ngZone.runOutsideAngular(() => (this.#element.nativeElement.value = value));
+    this.#ngZone.runOutsideAngular(() => {
+      this.#element.nativeElement.value = value;
+
+      // Re-apply the current select value in case Angular writes the form control value
+      // before it finishes binding the option values.
+      queueMicrotask(() => {
+        const select = this.#element.nativeElement.closest<SbbSelectElement<T>>('sbb-select');
+        const selectValue = select?.value;
+
+        if (
+          !select ||
+          selectValue === null ||
+          selectValue === undefined ||
+          (Array.isArray(selectValue) && selectValue.length === 0)
+        ) {
+          return;
+        }
+
+        select.value = selectValue;
+      });
+    });
   }
   public get value(): T {
     return this.#element.nativeElement.value;

--- a/src/angular/select/select.spec.ts
+++ b/src/angular/select/select.spec.ts
@@ -201,6 +201,29 @@ describe('sbb-select', () => {
       expect(component.select().getDisplayValue()).toEqual('Option 3 (test 3)');
     });
   });
+
+  describe('when option string values are bound after the initial form value write', () => {
+    let fixture: ComponentFixture<TestComponentLateBoundStringValue>,
+      component: TestComponentLateBoundStringValue;
+
+    beforeEach(async () => {
+      fixture = TestBed.createComponent(TestComponentLateBoundStringValue);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should update the initial selection once option values are available', async () => {
+      component.options()[0].value = 'option-1';
+      component.options()[1].value = 'option-2';
+      component.options()[2].value = 'option-3';
+      await Promise.resolve();
+
+      expect(component.options().map((o) => o.value)).toEqual(['option-1', 'option-2', 'option-3']);
+      expect(component.select().value).toEqual('option-2');
+      expect(component.select().getDisplayValue()).toEqual('Option 2');
+      expect(component.options().find((o) => o.value === 'option-2')?.selected).toBe(true);
+    });
+  });
 });
 
 @Component({
@@ -248,4 +271,19 @@ class TestComponentComplexValue {
   select: Signal<SbbSelect<(typeof this.values)[0]>> = viewChild.required(SbbSelect);
   options: Signal<readonly SbbOption<(typeof this.values)[0]>[]> = viewChildren(SbbOption);
   control = new FormControl(this.values[1]);
+}
+
+@Component({
+  selector: 'sbb-select-late-bound-string-value-test',
+  template: `<sbb-select [formControl]="control">
+    <sbb-option>Option 1</sbb-option>
+    <sbb-option>Option 2</sbb-option>
+    <sbb-option>Option 3</sbb-option>
+  </sbb-select>`,
+  imports: [SbbSelectModule, ReactiveFormsModule],
+})
+class TestComponentLateBoundStringValue {
+  select = viewChild.required(SbbSelect);
+  options = viewChildren(SbbOption);
+  control = new FormControl('option-2');
 }


### PR DESCRIPTION
This is an an attempt to fix #347 
I'm not overly confident this is the best approach..