### PR TITLE
docs: remove 'Example' suffix from description

### DIFF
--- a/src/docs/app/shared/example-data.ts
+++ b/src/docs/app/shared/example-data.ts
@@ -54,7 +54,7 @@ export class ExampleData {
     }
     this.selectorName = example.selectorName ?? `sbb-${example.id}-example`;
     this.indexFilename = example.indexFilename ?? `${example.id}-example.ts`;
-    this.description = example.description ?? exampleName.replace(/-+/g, ' ') + ' Example';
+    this.description = example.description ?? exampleName.replace(/-+/g, ' ');
     this.importPath = `${library}/${id}`;
     this.componentNames = example.componentNames ?? [this.name];
   }


### PR DESCRIPTION
Following #368, this PR removes the 'Example' suffix from the ExampleData's `description` setter to shorten the ToC content.