### PR TITLE
chore: examples common styles

### DIFF
--- a/src/docs/assets/stackblitz/src/styles.css
+++ b/src/docs/assets/stackblitz/src/styles.css
@@ -18,3 +18,12 @@ body {
   font-size: var(--sbb-text-font-size-xs);
   letter-spacing: var(--sbb-typo-letter-spacing-text);
 }
+
+sbb-card.form-value-box {
+  margin-block-start: var(--sbb-spacing-fixed-6x);
+}
+
+.controls {
+  display: flex;
+  gap: var(--sbb-spacing-fixed-8x);
+}

--- a/src/docs/assets/stackblitz/src/styles.css
+++ b/src/docs/assets/stackblitz/src/styles.css
@@ -19,11 +19,11 @@ body {
   letter-spacing: var(--sbb-typo-letter-spacing-text);
 }
 
-sbb-card.form-value-box {
+sbb-card.sbb-example__form-value-box {
   margin-block-start: var(--sbb-spacing-fixed-6x);
 }
 
-.controls {
+.sbb-example__controls {
   display: flex;
   gap: var(--sbb-spacing-fixed-8x);
 }

--- a/src/docs/styles.scss
+++ b/src/docs/styles.scss
@@ -104,12 +104,12 @@ sbb-block-link {
 }
 
 // Examples only - use this when you want to display the form value in a card.
-sbb-card.form-value-box {
+sbb-card.sbb-example__form-value-box {
   margin-block-start: var(--sbb-spacing-fixed-6x);
 }
 
 // Examples only - use this when you want to display a control panel with the component properties.
-.controls {
+.sbb-example__controls {
   display: flex;
   gap: var(--sbb-spacing-fixed-8x);
 }

--- a/src/docs/styles.scss
+++ b/src/docs/styles.scss
@@ -102,3 +102,14 @@ sbb-block-link {
   border-radius: var(--sbb-border-radius-2x);
   margin-block: var(--sbb-spacing-fixed-6x);
 }
+
+// Examples only - use this when you want to display the form value in a card.
+sbb-card.form-value-box {
+  margin-block-start: var(--sbb-spacing-fixed-6x);
+}
+
+// Examples only - use this when you want to display a control panel with the component properties.
+.controls {
+  display: flex;
+  gap: var(--sbb-spacing-fixed-8x);
+}


### PR DESCRIPTION
This PR adds some styles to use in examples only:
- the `.sbb-example__form-box` is meant to be used together with a card, like:
```
<sbb-form-field>
  <label>Autocomplete with group and hint</label>
  <input [formControl]="control" />
    ...
</sbb-form-field>

<sbb-card class="sbb-example__form-box" color="milk"> {{ control.value | json }}</sbb-card>
```

- the `.sbb-example__controls` is meant to be used whenever a control panel is needed:
```
<sbb-accordion [multi]="multi()" [size]="size()">
  <sbb-expansion-panel>
    <sbb-expansion-panel-header> First header </sbb-expansion-panel-header>
    <sbb-expansion-panel-content> Lorem ipsum </sbb-expansion-panel-content>
  </sbb-expansion-panel>
</sbb-accordion>

<sbb-title level="5">Properties</sbb-title>
<form [formGroup]="form" class="sbb-example__controls">
  <sbb-checkbox-group orientation="vertical">
    <sbb-checkbox formControlName="multi">Allows for multiple panel opened</sbb-checkbox>
    <sbb-checkbox formControlName="smallSize">Small size</sbb-checkbox>
  </sbb-checkbox-group>
</form>
```