### PR TITLE
fix(dialog,overlay): return null as close result for empty close attribute

### DIFF
--- a/src/angular/core/attribute-transform.ts
+++ b/src/angular/core/attribute-transform.ts
@@ -8,3 +8,11 @@ export function booleanAttribute(value: unknown): boolean {
     ? value
     : value !== 'false' && value !== undefined && value != null;
 }
+
+/**
+ * In case where we want to support empty inputs, we transform
+ * an empty string value to null.
+ */
+export function nullOnEmptyAttribute(value: unknown): unknown {
+  return value === '' ? null : value;
+}

--- a/src/angular/dialog/dialog-close/dialog-close.spec.ts
+++ b/src/angular/dialog/dialog-close/dialog-close.spec.ts
@@ -1,5 +1,5 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { Component, signal } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import type { SbbDialogCloseEvent } from '@sbb-esta/lyne-elements/dialog.js';
 
@@ -23,6 +23,10 @@ describe(`sbb-dialog-close`, () => {
       expect(fixture.nativeElement.querySelector('button').hasAttribute('sbb-dialog-close')).toBe(
         true,
       );
+    });
+
+    it('should transform empty attribute to null via nullOnEmptyAttribute', () => {
+      expect(fixture.componentInstance.directive().result).toBeNull();
     });
   });
 
@@ -132,7 +136,9 @@ describe(`sbb-dialog-close`, () => {
   template: `<button sbb-dialog-close>Label</button>`,
   imports: [SbbDialogClose],
 })
-class TestComponent {}
+class TestComponent {
+  directive = viewChild.required(SbbDialogClose);
+}
 
 @Component({
   template: `<div>Service Test Component</div>`,

--- a/src/angular/dialog/dialog-close/dialog-close.ts
+++ b/src/angular/dialog/dialog-close/dialog-close.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
+import { nullOnEmptyAttribute } from '@sbb-esta/lyne-angular/core';
 import { assignDialogResult } from '@sbb-esta/lyne-elements/dialog.js';
 
 /**
@@ -18,13 +19,15 @@ export class SbbDialogClose {
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
   /** Optional value to return when the dialog is closed. */
-  @Input('sbb-dialog-close')
+  @Input({ alias: 'sbb-dialog-close', transform: nullOnEmptyAttribute })
   public get result(): any {
     return this.#result;
   }
   public set result(value: any) {
     this.#result = value;
-    this.#ngZone.runOutsideAngular(() => assignDialogResult(this.#elementRef.nativeElement, value));
+    this.#ngZone.runOutsideAngular(() =>
+      assignDialogResult(this.#elementRef.nativeElement, this.#result),
+    );
   }
   #result: any = null;
   /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/angular/overlay/overlay-close/overlay-close.spec.ts
+++ b/src/angular/overlay/overlay-close/overlay-close.spec.ts
@@ -1,5 +1,5 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { Component, signal } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import type { SbbOverlayCloseEvent } from '@sbb-esta/lyne-elements/overlay.js';
 
@@ -22,6 +22,10 @@ describe(`sbb-overlay-close`, () => {
       expect(fixture.nativeElement.querySelector('button').hasAttribute('sbb-overlay-close')).toBe(
         true,
       );
+    });
+
+    it('should transform empty attribute to null via nullOnEmptyAttribute', () => {
+      expect(fixture.componentInstance.directive().result).toBeNull();
     });
   });
 
@@ -136,7 +140,9 @@ describe(`sbb-overlay-close`, () => {
   template: `<button sbb-overlay-close>Label</button>`,
   imports: [SbbOverlayClose],
 })
-class TestComponent {}
+class TestComponent {
+  directive = viewChild.required(SbbOverlayClose);
+}
 
 @Component({
   template: `<div>Service Test Component</div>`,

--- a/src/angular/overlay/overlay-close/overlay-close.ts
+++ b/src/angular/overlay/overlay-close/overlay-close.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, inject, Input, NgZone } from '@angular/core';
+import { nullOnEmptyAttribute } from '@sbb-esta/lyne-angular/core';
 import { assignOverlayResult } from '@sbb-esta/lyne-elements/overlay.js';
 
 /**
@@ -16,14 +17,14 @@ export class SbbOverlayClose {
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
   /** Optional value to return when the overlay is closed. */
-  @Input('sbb-overlay-close')
+  @Input({ alias: 'sbb-overlay-close', transform: nullOnEmptyAttribute })
   public get result(): any {
     return this.#result;
   }
   public set result(value: any) {
     this.#result = value;
     this.#ngZone.runOutsideAngular(() =>
-      assignOverlayResult(this.#elementRef.nativeElement, value),
+      assignOverlayResult(this.#elementRef.nativeElement, this.#result),
     );
   }
   #result: any = null;


### PR DESCRIPTION
Closes #386 