### PR TITLE
fix: treat `null` as (in)valid date in date and time input

### DIFF
--- a/scripts/merge-readme.mts
+++ b/scripts/merge-readme.mts
@@ -45,7 +45,7 @@ for (const dir of readdirSync(dirname(cachePath), { withFileTypes: true })
   )
   .map((d) => join(d.parentPath, d.name))) {
   console.log(`Removing old cache directory ${relative(projectRoot, dir)}`);
-  rmSync(dir, { force: true });
+  rmSync(dir, { force: true, recursive: true });
 }
 
 const guidesIncludeList = ['datetime', 'layout', 'theming'];
@@ -75,21 +75,24 @@ async function writeGuides(path: string, newContent: string) {
     .replace(/^import\s+(?:[\s\w{},*]+?\s+from\s+)?['"][^'"]+['"];?/gm, '')
 
     // Convert inline stories
-    .replace(/(<InlineStory\b[^>]*>)([\s\S]*?)(<\/InlineStory>)/gi, (_, _open, content, _close) => {
-      // Remove completely empty lines as otherwise they are interpreted as html paragraph by markdown.
-      const cleaned = content
-        .split(/\r?\n/) // Split into lines
-        .filter((line) => line.trim()) // Keep lines with content
-        .join('\n') // Join back with line breaks
+    .replace(
+      /(<InlineStory\b[^>]*>)([\s\S]*?)(<\/InlineStory>)/gi,
+      (_, _open, content: string, _close) => {
+        // Remove completely empty lines as otherwise they are interpreted as html paragraph by markdown.
+        const cleaned = content
+          .split(/\r?\n/) // Split into lines
+          .filter((line) => line.trim()) // Keep lines with content
+          .join('\n') // Join back with line breaks
 
-        // Remove tsx style brackets
-        .replaceAll('{`', '')
-        .replaceAll('`}', '')
+          // Remove tsx style brackets
+          .replaceAll('{`', '')
+          .replaceAll('`}', '')
 
-        // Remove all whitespaces within style tags to later interpret it correctly
-        .replace(/(<style\b[^>]*>)\s*([\s\S]*?)\s*(<\/style>)/gi, '$1$2$3');
-      return '<div class="sbb-inline-story">' + '\n' + cleaned + '\n' + '</div>';
-    });
+          // Remove all whitespaces within style tags to later interpret it correctly
+          .replace(/(<style\b[^>]*>)\s*([\s\S]*?)\s*(<\/style>)/gi, '$1$2$3');
+        return '<div class="sbb-inline-story">' + '\n' + cleaned + '\n' + '</div>';
+      },
+    );
 
   newContent = convertDocsLinks(newContent);
   newContent = convertHtmlExamples(newContent);

--- a/src/angular/date-input/date-input.spec.ts
+++ b/src/angular/date-input/date-input.spec.ts
@@ -136,7 +136,7 @@ describe('sbb-date-input', () => {
     // Test with undefined
     control.setValue(undefined as unknown as Date);
     expect(dateInput.valueAsDate).toBeNull();
-    expect(dateInput.value).toEqual('undefined');
+    expect(dateInput.value).toEqual('');
   });
 
   it('should be touched on blur', async () => {

--- a/src/angular/date-input/date-input.ts
+++ b/src/angular/date-input/date-input.ts
@@ -255,8 +255,11 @@ export class SbbDateInput<T = Date>
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   override writeValue(value: any): void {
-    if (this.#dateAdapter.isDateInstance(value) && this.#dateAdapter.isValid(value)) {
-      this.valueAsDate = value;
+    if (
+      value == null ||
+      (this.#dateAdapter.isDateInstance(value) && this.#dateAdapter.isValid(value))
+    ) {
+      this.valueAsDate = value ?? null;
     } else {
       this.valueAsDate = this.#dateAdapter.parse(value);
       if (!this.valueAsDate) {

--- a/src/angular/time-input/time-input.ts
+++ b/src/angular/time-input/time-input.ts
@@ -174,8 +174,8 @@ export class SbbTimeInput extends SbbControlValueAccessorMixin(class {}) impleme
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   override writeValue(value: any): void {
-    if (value instanceof Date) {
-      this.valueAsDate = value;
+    if (value instanceof Date || value == null) {
+      this.valueAsDate = value ?? null;
     } else {
       this.value = value;
     }


### PR DESCRIPTION
Currently `null` is not considered a date, which causes the value in the ControlValueAccessor to be assigned to the `value` property of the date and input input. We however want `null` to be assigned to the `valueAsDate` property, which this PR addresses.

Relates to #316