### PR TITLE
docs(how-to-update): add 'how-to-update' guide

### DIFF
--- a/src/docs/app/angular/angular-routing.module.ts
+++ b/src/docs/app/angular/angular-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import type { Routes } from '@angular/router';
 import { RouterModule } from '@angular/router';
 
+import { HowToUpdateComponent } from '../how-to-update/how-to-update';
 import { componentViewerSubnavigation } from '../shared/component-viewer/component-viewer/component-viewer-subnavigation';
 import { ComponentViewerComponent } from '../shared/component-viewer/component-viewer/component-viewer.component';
 import type { LoaderBuilder } from '../shared/loader-builder';
@@ -28,6 +29,10 @@ const routes: Routes = [
       //   path: 'icon-overview',
       //   component: IconOverviewComponent,
       // },
+      {
+        path: 'guides/how-to-update',
+        component: HowToUpdateComponent,
+      },
       {
         path: 'guides/:id',
         component: MarkdownViewerComponent,

--- a/src/docs/app/how-to-update/how-to-update.html
+++ b/src/docs/app/how-to-update/how-to-update.html
@@ -38,8 +38,9 @@
     }}</sbb-title
   >
   <p>
-    Before starting, have a look at the <sbb-link [href]="step.changelog">CHANGELOG</sbb-link> of
-    Lyne elements
+    Before starting, have a look at
+    <sbb-link [href]="step.lyneChangelog">Lyne Elements</sbb-link> and
+    <sbb-link [href]="step.ngChangelog">Lyne Angular</sbb-link> CHANGELOG.
   </p>
   <ol>
     @for (action of step.actions; track action) {

--- a/src/docs/app/how-to-update/how-to-update.html
+++ b/src/docs/app/how-to-update/how-to-update.html
@@ -1,0 +1,50 @@
+<sbb-title level="1">How to update</sbb-title>
+
+<form class="sbb-form-group">
+  <sbb-form-field>
+    <label>From</label>
+    <sbb-select [formField]="versionForm.from">
+      @for (v of versions; track v) {
+      <sbb-option [value]="v">{{ toVersionString(v) }}</sbb-option>
+      }
+    </sbb-select>
+  </sbb-form-field>
+
+  <sbb-form-field>
+    <label>To</label>
+    <sbb-select [formField]="versionForm.to">
+      @for (v of versions; track v) {
+      <sbb-option [value]="v">{{ toVersionString(v) }}</sbb-option>
+      }
+    </sbb-select>
+  </sbb-form-field>
+</form>
+
+@if (versionForm.to().value() - versionForm.from().value() > 150) {
+<sbb-notification type="warn">
+  We do not support migrating across multiple major versions at once. Please migrate each major
+  version individually.
+</sbb-notification>
+} @if (versionForm.to().value() < versionForm.from().value()) {
+<sbb-notification type="error">
+  We do not support downgrading versions of Lyne Angular.
+</sbb-notification>
+} @if (versionForm.to().value() === versionForm.from().value()) {
+<sbb-notification type="success"> There's nothing to do. </sbb-notification>
+} @for (step of updateSteps(); track step) {
+<div>
+  <sbb-title level="4"
+    >Update from Version {{ toVersionString(step.from) }} to {{ toVersionString(step.to)
+    }}</sbb-title
+  >
+  <p>
+    Before starting, have a look at the <sbb-link [href]="step.changelog">CHANGELOG</sbb-link> of
+    Lyne elements
+  </p>
+  <ol>
+    @for (action of step.actions; track action) {
+    <li [innerHTML]="toSafeHtml(action)"></li>
+    }
+  </ol>
+</div>
+}

--- a/src/docs/app/how-to-update/how-to-update.scss
+++ b/src/docs/app/how-to-update/how-to-update.scss
@@ -1,0 +1,5 @@
+.sbb-form-group {
+  display: flex;
+  gap: var(--sbb-spacing-fixed-2x);
+  padding-block: var(--sbb-spacing-fixed-2x);
+}

--- a/src/docs/app/how-to-update/how-to-update.ts
+++ b/src/docs/app/how-to-update/how-to-update.ts
@@ -1,0 +1,40 @@
+import { Component, inject, linkedSignal, signal } from '@angular/core';
+import { form, FormField } from '@angular/forms/signals';
+import { DomSanitizer, type SafeHtml } from '@angular/platform-browser';
+import { SbbFormField } from '@sbb-esta/lyne-angular/form-field';
+import { SbbLink } from '@sbb-esta/lyne-angular/link';
+import { SbbNotification } from '@sbb-esta/lyne-angular/notification';
+import { SbbSelectModule } from '@sbb-esta/lyne-angular/select';
+import { SbbTitle } from '@sbb-esta/lyne-angular/title';
+
+import { UPDATE_STEPS } from './update-steps';
+
+@Component({
+  selector: 'sbb-how-to-update',
+  imports: [SbbTitle, SbbFormField, SbbLink, SbbNotification, SbbSelectModule, FormField],
+  templateUrl: './how-to-update.html',
+  styleUrl: './how-to-update.scss',
+})
+export class HowToUpdateComponent {
+  readonly #domSanitizer = inject(DomSanitizer);
+
+  protected versionForm = form(signal({ from: 2100, to: 2200 }));
+
+  protected versions: number[] = [
+    ...new Set([...UPDATE_STEPS.map((s) => s.from), ...UPDATE_STEPS.map((s) => s.to)]),
+  ].sort();
+
+  protected updateSteps = linkedSignal(() =>
+    UPDATE_STEPS.filter(
+      (s) => this.versionForm.from().value() <= s.from && s.to <= this.versionForm.to().value(),
+    ),
+  );
+
+  toVersionString(version: number) {
+    return `${version / 100}.${version % 100}`;
+  }
+
+  toSafeHtml(html: string): SafeHtml {
+    return this.#domSanitizer.bypassSecurityTrustHtml(html);
+  }
+}

--- a/src/docs/app/how-to-update/how-to-update.ts
+++ b/src/docs/app/how-to-update/how-to-update.ts
@@ -1,4 +1,4 @@
-import { Component, inject, linkedSignal, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { form, FormField } from '@angular/forms/signals';
 import { DomSanitizer, type SafeHtml } from '@angular/platform-browser';
 import { SbbFormField } from '@sbb-esta/lyne-angular/form-field';
@@ -18,13 +18,13 @@ import { UPDATE_STEPS } from './update-steps';
 export class HowToUpdateComponent {
   readonly #domSanitizer = inject(DomSanitizer);
 
-  protected versionForm = form(signal({ from: 2100, to: 2200 }));
-
   protected versions: number[] = [
     ...new Set([...UPDATE_STEPS.map((s) => s.from), ...UPDATE_STEPS.map((s) => s.to)]),
   ].sort();
 
-  protected updateSteps = linkedSignal(() =>
+  protected versionForm = form(signal({ from: this.versions.at(-2)!, to: this.versions.at(-1)! }));
+
+  protected updateSteps = computed(() =>
     UPDATE_STEPS.filter(
       (s) => this.versionForm.from().value() <= s.from && s.to <= this.versionForm.to().value(),
     ),

--- a/src/docs/app/how-to-update/update-steps.ts
+++ b/src/docs/app/how-to-update/update-steps.ts
@@ -1,7 +1,8 @@
 export interface UpdateStep {
   from: number;
   to: number;
-  changelog: string;
+  lyneChangelog: string;
+  ngChangelog: string;
   actions: string[];
 }
 
@@ -9,7 +10,8 @@ export const UPDATE_STEPS: UpdateStep[] = [
   {
     from: 2100,
     to: 2200,
-    changelog: 'https://github.com/sbb-design-systems/lyne-components/releases/tag/v5.0.0',
+    lyneChangelog: 'https://github.com/sbb-design-systems/lyne-components/releases/tag/v5.0.0',
+    ngChangelog: 'https://github.com/sbb-design-systems/lyne-angular/releases/tag/v22.0.0',
     actions: [
       `<p>
         Update your Angular dependencies to version 22.x.x with "--force" flag (due to unmet peer dependencies).<br/>

--- a/src/docs/app/how-to-update/update-steps.ts
+++ b/src/docs/app/how-to-update/update-steps.ts
@@ -1,0 +1,27 @@
+export interface UpdateStep {
+  from: number;
+  to: number;
+  changelog: string;
+  actions: string[];
+}
+
+export const UPDATE_STEPS: UpdateStep[] = [
+  {
+    from: 2100,
+    to: 2200,
+    changelog: 'https://github.com/sbb-design-systems/lyne-components/releases/tag/v5.0.0',
+    actions: [
+      `<p>
+        Update your Angular dependencies to version 22.x.x with "--force" flag (due to unmet peer dependencies).<br/>
+        See <sbb-link href='https://update.angular.io'>update.angular.io</sbb-link> for a step-by-step guide for updating Angular.
+      </p>
+      <pre><code class="hljs">npx @angular/cli@22 update @angular/core@22 @angular/cli@22 --force</code></pre>`,
+
+      `<p>Update Angular CDK in a separate step to avoid dependency version resolving problems.</p>
+       <pre><code class="hljs">npx @angular/cli@22 update @angular/cdk@22 --force</code></pre>`,
+
+      `<p>Finally, update Lyne Angular.</p>
+       <pre><code class="hljs">ng update @sbb-esta/lyne-angular@22</code></pre>`,
+    ],
+  },
+];

--- a/src/docs/app/shared/meta.ts
+++ b/src/docs/app/shared/meta.ts
@@ -28,6 +28,7 @@ export const PACKAGES: Record<string, ShowcaseMetaPackage> = {
         name: 'Guides',
         entries: [
           { label: 'Getting started', link: './guides/getting-started' },
+          { label: 'How to update', link: './guides/how-to-update' },
           { label: 'Theming', link: './guides/theming' },
           { label: 'Layout', link: './guides/layout' },
           { label: 'Datetime', link: './guides/datetime' },


### PR DESCRIPTION
I moved the entry point for the 'how-to-update' page under the Lyne Angular guides. We can discuss it eventually