### PR TITLE
refactor: provide own overlay config for overlay module

### DIFF
--- a/scripts/api-generator.mts
+++ b/scripts/api-generator.mts
@@ -103,6 +103,7 @@ const getModuleNamesFromMeta = async (projectFolder: string): Promise<string[]> 
  *
  * NOTE: since there could be cases of folders with the same name (e.g. `angular/overlay` and `angular/core/overlay`),
  * the `api` folder is deleted and recreated every time and the readme file is created with the 'append' flag (`a`).
+ * TODO: Check whether still necessary
  *
  * @param projectFolder the name of the package (angular / angular-experimental / ...)
  */

--- a/src/angular/core/index.ts
+++ b/src/angular/core/index.ts
@@ -6,6 +6,6 @@ export * from './deferred-animation';
 export * from './internal-output-from-observable';
 export * from './overlay/focus-initial';
 export * from './overlay/overlay-base';
-export * from './overlay/overlay-config';
+export * from './overlay/overlay-config-base';
 export * from './overlay/overlay-container-base';
 export * from './overlay/overlay-base-ref';

--- a/src/angular/core/index.ts
+++ b/src/angular/core/index.ts
@@ -4,3 +4,8 @@ export * from './datetime/provide-native-date-adapter';
 export * from './datetime/provide-temporal-date-adapter';
 export * from './deferred-animation';
 export * from './internal-output-from-observable';
+export * from './overlay/focus-initial';
+export * from './overlay/overlay-base';
+export * from './overlay/overlay-config';
+export * from './overlay/overlay-container-base';
+export * from './overlay/overlay-base-ref';

--- a/src/angular/core/overlay/index.ts
+++ b/src/angular/core/overlay/index.ts
@@ -1,5 +1,0 @@
-export * from './focus-initial';
-export * from './overlay-base';
-export * from './overlay-config';
-export * from './overlay-container-base';
-export * from './overlay-base-ref';

--- a/src/angular/core/overlay/ng-package.json
+++ b/src/angular/core/overlay/ng-package.json
@@ -1,5 +1,0 @@
-{
-  "lib": {
-    "entryFile": "index.ts"
-  }
-}

--- a/src/angular/core/overlay/overlay-base-ref.ts
+++ b/src/angular/core/overlay/overlay-base-ref.ts
@@ -4,7 +4,7 @@ import type { ComponentRef } from '@angular/core';
 import type { SubscriptionLike, Observable } from 'rxjs';
 import { share, Subscription, take, takeUntil } from 'rxjs';
 
-import type { SbbOverlayBaseConfig } from './overlay-config';
+import type { SbbOverlayBaseConfig } from './overlay-config-base';
 import type { SbbOverlayContainerBase } from './overlay-container-base';
 
 /** Possible states of the lifecycle of an overlay. */

--- a/src/angular/core/overlay/overlay-base-ref.ts
+++ b/src/angular/core/overlay/overlay-base-ref.ts
@@ -4,7 +4,7 @@ import type { ComponentRef } from '@angular/core';
 import type { SubscriptionLike, Observable } from 'rxjs';
 import { share, Subscription, take, takeUntil } from 'rxjs';
 
-import type { SbbOverlayConfig } from './overlay-config';
+import type { SbbOverlayBaseConfig } from './overlay-config';
 import type { SbbOverlayContainerBase } from './overlay-container-base';
 
 /** Possible states of the lifecycle of an overlay. */
@@ -32,7 +32,7 @@ export class SbbOverlayBaseRef<T = unknown, C extends Event = Event> {
 
   constructor(
     container: SbbOverlayContainerBase<unknown, C>,
-    config: SbbOverlayConfig<SbbOverlayContainerBase<unknown, C>>,
+    config: SbbOverlayBaseConfig<SbbOverlayContainerBase<unknown, C>>,
     portalOutlet: DomPortalOutlet,
     location: Location,
   ) {

--- a/src/angular/core/overlay/overlay-base.ts
+++ b/src/angular/core/overlay/overlay-base.ts
@@ -19,7 +19,7 @@ import {
 import { defer, type Observable, startWith, Subject } from 'rxjs';
 
 import type { SbbOverlayBaseRef } from './overlay-base-ref';
-import { SbbOverlayBaseConfig } from './overlay-config';
+import type { SbbOverlayBaseConfig } from './overlay-config-base';
 import type { SbbOverlayContainerBase } from './overlay-container-base';
 
 /** Injection token that can be used to access the data that was passed in to an overlay. */
@@ -47,7 +47,7 @@ export abstract class SbbOverlayBaseService<
     const userInjector = config.injector || config.viewContainerRef?.injector;
     const providers: StaticProvider[] = [
       { provide: this.containerType, useValue: overlayContainer },
-      { provide: this.overlayRefConstructor, useValue: overlayRef },
+      { provide: this.refConstructor, useValue: overlayRef },
     ];
 
     if (config.data) {
@@ -68,7 +68,7 @@ export abstract class SbbOverlayBaseService<
     const containerType: Type<C> = this.containerType;
     const userInjector = config.injector || config.viewContainerRef?.injector;
     const providers: StaticProvider[] = [
-      { provide: SbbOverlayBaseConfig, useValue: config },
+      { provide: this.configType, useValue: config },
       { provide: DomPortalOutlet, useValue: portalOutlet },
     ];
     const containerPortal = new ComponentPortal(
@@ -171,7 +171,7 @@ export abstract class SbbOverlayBaseService<
     );
     const overlayContainer = this.#attachContainer(portalOutlet, config);
 
-    const overlayRefConstructed = new this.overlayRefConstructor(
+    const overlayRefConstructed = new this.refConstructor(
       overlayContainer,
       config,
       portalOutlet,
@@ -237,7 +237,8 @@ export abstract class SbbOverlayBaseService<
 
   protected abstract parentService: SbbOverlayBaseService<C, I, R> | null;
   protected abstract containerType: Type<C>;
-  protected abstract overlayRefConstructor: Type<R>;
+  protected abstract refConstructor: Type<R>;
+  protected abstract configType: Type<unknown>;
   protected overlayDataToken: InjectionToken<unknown> = SBB_OVERLAY_DATA;
 
   #injector = inject(Injector);

--- a/src/angular/core/overlay/overlay-base.ts
+++ b/src/angular/core/overlay/overlay-base.ts
@@ -19,7 +19,7 @@ import {
 import { defer, type Observable, startWith, Subject } from 'rxjs';
 
 import type { SbbOverlayBaseRef } from './overlay-base-ref';
-import { SbbOverlayConfig } from './overlay-config';
+import { SbbOverlayBaseConfig } from './overlay-config';
 import type { SbbOverlayContainerBase } from './overlay-container-base';
 
 /** Injection token that can be used to access the data that was passed in to an overlay. */
@@ -39,7 +39,7 @@ export abstract class SbbOverlayBaseService<
   #idGenerator = inject(_IdGenerator);
 
   #createInjector<D>(
-    config: SbbOverlayConfig<C, I, D>,
+    config: SbbOverlayBaseConfig<C, I, D>,
     overlayRef: R,
     overlayContainer: C,
     fallbackInjector: Injector,
@@ -64,11 +64,11 @@ export abstract class SbbOverlayBaseService<
     return Injector.create({ providers, parent: userInjector || fallbackInjector });
   }
 
-  #attachContainer(portalOutlet: DomPortalOutlet, config: SbbOverlayConfig<C, I>): C {
+  #attachContainer(portalOutlet: DomPortalOutlet, config: SbbOverlayBaseConfig<C, I>): C {
     const containerType: Type<C> = this.containerType;
     const userInjector = config.injector || config.viewContainerRef?.injector;
     const providers: StaticProvider[] = [
-      { provide: SbbOverlayConfig, useValue: config },
+      { provide: SbbOverlayBaseConfig, useValue: config },
       { provide: DomPortalOutlet, useValue: portalOutlet },
     ];
     const containerPortal = new ComponentPortal(
@@ -111,7 +111,7 @@ export abstract class SbbOverlayBaseService<
     componentOrTemplateRef: ComponentType<D> | TemplateRef<D>,
     overlayRef: R,
     overlayContainer: C,
-    config: SbbOverlayConfig<C, I, D>,
+    config: SbbOverlayBaseConfig<C, I, D>,
   ) {
     const injector = this.#createInjector(config, overlayRef, overlayContainer, this.#injector);
     if (componentOrTemplateRef instanceof TemplateRef) {
@@ -145,7 +145,7 @@ export abstract class SbbOverlayBaseService<
 
   open<T = unknown>(
     componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-    config: SbbOverlayConfig<C, I> = {},
+    config: SbbOverlayBaseConfig<C, I> = {},
   ): SbbOverlayBaseRef<T> {
     config.id = config.id || this.#idGenerator.getId('cdk-overlay-');
 

--- a/src/angular/core/overlay/overlay-config-base.ts
+++ b/src/angular/core/overlay/overlay-config-base.ts
@@ -29,7 +29,7 @@ export class SbbOverlayBaseConfig<C extends SbbOverlayContainerBase, I = unknown
     | StaticProvider[]
     | ((
         overlayRef: SbbOverlayBaseRef,
-        config: SbbOverlayBaseConfig<C, I>,
+        config: SbbOverlayBaseConfig<C, I, D>,
         container: C,
       ) => StaticProvider[]);
 

--- a/src/angular/core/overlay/overlay-config.ts
+++ b/src/angular/core/overlay/overlay-config.ts
@@ -3,7 +3,7 @@ import type { Injector, StaticProvider, ViewContainerRef } from '@angular/core';
 import type { SbbOverlayBaseRef } from './overlay-base-ref';
 import type { SbbOverlayContainerBase } from './overlay-container-base';
 
-export class SbbOverlayConfig<C extends SbbOverlayContainerBase, I = unknown, D = unknown> {
+export class SbbOverlayBaseConfig<C extends SbbOverlayContainerBase, I = unknown, D = unknown> {
   /**
    * Where the attached component should live in Angular's *logical* component tree.
    * This affects what is available for injection and the change detection order for the
@@ -29,7 +29,7 @@ export class SbbOverlayConfig<C extends SbbOverlayContainerBase, I = unknown, D 
     | StaticProvider[]
     | ((
         overlayRef: SbbOverlayBaseRef,
-        config: SbbOverlayConfig<C, I>,
+        config: SbbOverlayBaseConfig<C, I>,
         container: C,
       ) => StaticProvider[]);
 

--- a/src/angular/dialog/dialog.module.ts
+++ b/src/angular/dialog/dialog.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core';
 
 import { SbbDialog } from './dialog/dialog';
 import { SbbDialogContainer } from './dialog/dialog-container';

--- a/src/angular/dialog/dialog/dialog-config.ts
+++ b/src/angular/dialog/dialog/dialog-config.ts
@@ -1,0 +1,10 @@
+import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core/overlay';
+
+import type { SbbDialog } from './dialog';
+import type { SbbDialogContainer } from './dialog-container';
+
+export class SbbDialogConfig<
+  C extends SbbDialogContainer,
+  I = SbbDialog,
+  D = unknown,
+> extends SbbOverlayBaseConfig<C, I, D> {}

--- a/src/angular/dialog/dialog/dialog-config.ts
+++ b/src/angular/dialog/dialog/dialog-config.ts
@@ -1,4 +1,5 @@
-import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core';
+import type { StaticProvider } from '@angular/core';
+import { SbbOverlayBaseConfig, type SbbOverlayBaseRef } from '@sbb-esta/lyne-angular/core';
 
 import type { SbbDialog } from './dialog';
 import type { SbbDialogContainer } from './dialog-container';
@@ -7,4 +8,16 @@ export class SbbDialogConfig<
   C extends SbbDialogContainer,
   I = SbbDialog,
   D = unknown,
-> extends SbbOverlayBaseConfig<C, I, D> {}
+> extends SbbOverlayBaseConfig<C, I, D> {
+  /**
+   * Providers that will be exposed to the contents of the dialog. Can also
+   * be provided as a function in order to generate the providers lazily.
+   */
+  declare providers?:
+    | StaticProvider[]
+    | ((
+        overlayRef: SbbOverlayBaseRef,
+        config: SbbDialogConfig<C, I, D>,
+        container: C,
+      ) => StaticProvider[]);
+}

--- a/src/angular/dialog/dialog/dialog-config.ts
+++ b/src/angular/dialog/dialog/dialog-config.ts
@@ -1,4 +1,4 @@
-import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core';
 
 import type { SbbDialog } from './dialog';
 import type { SbbDialogContainer } from './dialog-container';

--- a/src/angular/dialog/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog/dialog-container.ts
@@ -7,15 +7,12 @@ import {
   viewChild,
 } from '@angular/core';
 import { outputToObservable } from '@angular/core/rxjs-interop';
-import {
-  SbbOverlayConfig,
-  SbbOverlayContainerBase,
-  SbbOverlayState,
-} from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayContainerBase, SbbOverlayState } from '@sbb-esta/lyne-angular/core/overlay';
 import type { SbbDialogCloseEvent } from '@sbb-esta/lyne-elements/dialog.pure.js';
 import type { Observable } from 'rxjs';
 
 import { SbbDialog } from './dialog';
+import { SbbDialogConfig } from './dialog-config';
 
 /**
  * Container component for `SbbDialog` components.
@@ -35,8 +32,8 @@ import { SbbDialog } from './dialog';
   template: `<ng-template cdkPortalOutlet></ng-template>`,
 })
 export class SbbDialogContainer extends SbbOverlayContainerBase<SbbDialog> {
-  readonly _config: SbbOverlayConfig<SbbDialogContainer, SbbDialog, unknown> =
-    inject(SbbOverlayConfig, { optional: true }) || {};
+  readonly _config: SbbDialogConfig<SbbDialogContainer> =
+    inject(SbbDialogConfig, { optional: true }) || {};
 
   /** The portal outlet inside of this container into which the dialog content will be loaded. */
   public elementInstance = inject(SbbDialog)!;

--- a/src/angular/dialog/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog/dialog-container.ts
@@ -33,7 +33,7 @@ import { SbbDialogConfig } from './dialog-config';
 })
 export class SbbDialogContainer extends SbbOverlayContainerBase<SbbDialog> {
   readonly _config: SbbDialogConfig<SbbDialogContainer> =
-    inject(SbbDialogConfig, { optional: true }) || {};
+    inject(SbbDialogConfig<SbbDialogContainer>, { optional: true }) || {};
 
   /** The portal outlet inside of this container into which the dialog content will be loaded. */
   public elementInstance = inject(SbbDialog)!;

--- a/src/angular/dialog/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog/dialog-container.ts
@@ -7,7 +7,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { outputToObservable } from '@angular/core/rxjs-interop';
-import { SbbOverlayContainerBase, SbbOverlayState } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayContainerBase, SbbOverlayState } from '@sbb-esta/lyne-angular/core';
 import type { SbbDialogCloseEvent } from '@sbb-esta/lyne-elements/dialog.pure.js';
 import type { Observable } from 'rxjs';
 

--- a/src/angular/dialog/dialog/dialog-ref.ts
+++ b/src/angular/dialog/dialog/dialog-ref.ts
@@ -1,4 +1,4 @@
-import { SbbOverlayBaseRef } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseRef } from '@sbb-esta/lyne-angular/core';
 import type { SbbDialogCloseEvent } from '@sbb-esta/lyne-elements/dialog.pure.js';
 
 export class SbbDialogRef<T = unknown, R = unknown> extends SbbOverlayBaseRef<

--- a/src/angular/dialog/dialog/dialog-service.ts
+++ b/src/angular/dialog/dialog/dialog-service.ts
@@ -1,8 +1,9 @@
 import type { ComponentType } from '@angular/cdk/overlay';
 import { inject, Service, type TemplateRef } from '@angular/core';
-import { SbbOverlayBaseService, type SbbOverlayConfig } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core/overlay';
 
 import type { SbbDialog } from './dialog';
+import type { SbbDialogConfig } from './dialog-config';
 import { SbbDialogContainer } from './dialog-container';
 import { SbbDialogRef } from './dialog-ref';
 
@@ -18,7 +19,7 @@ export class SbbDialogService extends SbbOverlayBaseService<
 
   public override open<T = unknown, R = unknown>(
     componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-    config?: SbbOverlayConfig<SbbDialogContainer, SbbDialog>,
+    config?: SbbDialogConfig<SbbDialogContainer>,
   ): SbbDialogRef<T, R> {
     return super.open(componentOrTemplateRef, config) as SbbDialogRef<T, R>;
   }

--- a/src/angular/dialog/dialog/dialog-service.ts
+++ b/src/angular/dialog/dialog/dialog-service.ts
@@ -3,7 +3,7 @@ import { inject, Service, type TemplateRef } from '@angular/core';
 import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core';
 
 import type { SbbDialog } from './dialog';
-import type { SbbDialogConfig } from './dialog-config';
+import { SbbDialogConfig } from './dialog-config';
 import { SbbDialogContainer } from './dialog-container';
 import { SbbDialogRef } from './dialog-ref';
 
@@ -15,7 +15,8 @@ export class SbbDialogService extends SbbOverlayBaseService<
 > {
   protected parentService = inject(SbbDialogService, { optional: true, skipSelf: true });
   protected containerType = SbbDialogContainer;
-  protected overlayRefConstructor = SbbDialogRef;
+  protected refConstructor = SbbDialogRef;
+  protected configType = SbbDialogConfig;
 
   public override open<T = unknown, R = unknown>(
     componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,

--- a/src/angular/dialog/dialog/dialog-service.ts
+++ b/src/angular/dialog/dialog/dialog-service.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from '@angular/cdk/overlay';
 import { inject, Service, type TemplateRef } from '@angular/core';
-import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core';
 
 import type { SbbDialog } from './dialog';
 import type { SbbDialogConfig } from './dialog-config';

--- a/src/angular/dialog/dialog/dialog.spec.ts
+++ b/src/angular/dialog/dialog/dialog.spec.ts
@@ -11,7 +11,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
-import { SBB_OVERLAY_DATA } from '@sbb-esta/lyne-angular/core/overlay';
+import { SBB_OVERLAY_DATA } from '@sbb-esta/lyne-angular/core';
 
 import { SbbDialog } from './dialog';
 import { SbbDialogRef } from './dialog-ref';

--- a/src/angular/dialog/index.ts
+++ b/src/angular/dialog/index.ts
@@ -1,4 +1,5 @@
 export * from './dialog/dialog';
+export * from './dialog/dialog-config';
 export * from './dialog/dialog-container';
 export * from './dialog/dialog-ref';
 export * from './dialog/dialog-service';

--- a/src/angular/menu/menu.module.ts
+++ b/src/angular/menu/menu.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core';
 
 import { SbbMenu } from './menu/menu';
 import { SbbMenuButton } from './menu-button/menu-button';

--- a/src/angular/navigation/navigation.module.ts
+++ b/src/angular/navigation/navigation.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core';
 
 import { SbbNavigation } from './navigation/navigation';
 import { SbbNavigationButton } from './navigation-button/navigation-button';

--- a/src/angular/overlay/index.ts
+++ b/src/angular/overlay/index.ts
@@ -1,5 +1,6 @@
 export * from './overlay';
 export * from './overlay-close/overlay-close';
+export * from './overlay-config';
 export * from './overlay-container';
 export * from './overlay-ref';
 export * from './overlay-service';

--- a/src/angular/overlay/overlay-config.ts
+++ b/src/angular/overlay/overlay-config.ts
@@ -1,4 +1,5 @@
-import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core';
+import type { StaticProvider } from '@angular/core';
+import { SbbOverlayBaseConfig, type SbbOverlayBaseRef } from '@sbb-esta/lyne-angular/core';
 
 import type { SbbOverlay } from './overlay';
 import type { SbbOverlayContainer } from './overlay-container';
@@ -7,4 +8,16 @@ export class SbbOverlayConfig<
   C extends SbbOverlayContainer,
   I = SbbOverlay,
   D = unknown,
-> extends SbbOverlayBaseConfig<C, I, D> {}
+> extends SbbOverlayBaseConfig<C, I, D> {
+  /**
+   * Providers that will be exposed to the contents of the dialog. Can also
+   * be provided as a function in order to generate the providers lazily.
+   */
+  declare providers?:
+    | StaticProvider[]
+    | ((
+        overlayRef: SbbOverlayBaseRef,
+        config: SbbOverlayConfig<C, I, D>,
+        container: C,
+      ) => StaticProvider[]);
+}

--- a/src/angular/overlay/overlay-config.ts
+++ b/src/angular/overlay/overlay-config.ts
@@ -1,4 +1,4 @@
-import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core';
 
 import type { SbbOverlay } from './overlay';
 import type { SbbOverlayContainer } from './overlay-container';

--- a/src/angular/overlay/overlay-config.ts
+++ b/src/angular/overlay/overlay-config.ts
@@ -1,0 +1,10 @@
+import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core/overlay';
+
+import type { SbbOverlay } from './overlay';
+import type { SbbOverlayContainer } from './overlay-container';
+
+export class SbbOverlayConfig<
+  C extends SbbOverlayContainer,
+  I = SbbOverlay,
+  D = unknown,
+> extends SbbOverlayBaseConfig<C, I, D> {}

--- a/src/angular/overlay/overlay-container.ts
+++ b/src/angular/overlay/overlay-container.ts
@@ -7,7 +7,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { outputToObservable } from '@angular/core/rxjs-interop';
-import { SbbOverlayContainerBase, SbbOverlayState } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayContainerBase, SbbOverlayState } from '@sbb-esta/lyne-angular/core';
 import type { SbbOverlayCloseEvent } from '@sbb-esta/lyne-elements/overlay.pure.js';
 import type { Observable } from 'rxjs';
 

--- a/src/angular/overlay/overlay-container.ts
+++ b/src/angular/overlay/overlay-container.ts
@@ -7,15 +7,12 @@ import {
   viewChild,
 } from '@angular/core';
 import { outputToObservable } from '@angular/core/rxjs-interop';
-import {
-  SbbOverlayConfig,
-  SbbOverlayContainerBase,
-  SbbOverlayState,
-} from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayContainerBase, SbbOverlayState } from '@sbb-esta/lyne-angular/core/overlay';
 import type { SbbOverlayCloseEvent } from '@sbb-esta/lyne-elements/overlay.pure.js';
 import type { Observable } from 'rxjs';
 
 import { SbbOverlay } from './overlay';
+import { SbbOverlayConfig } from './overlay-config';
 
 /**
  * Container component for `SbbOverlay` components.
@@ -35,7 +32,7 @@ import { SbbOverlay } from './overlay';
   template: `<ng-template cdkPortalOutlet></ng-template>`,
 })
 export class SbbOverlayContainer extends SbbOverlayContainerBase<SbbOverlay> {
-  readonly _config: SbbOverlayConfig<SbbOverlayContainer, SbbOverlay, unknown> =
+  readonly _config: SbbOverlayConfig<SbbOverlayContainer> =
     inject(SbbOverlayConfig, { optional: true }) || {};
 
   /** The portal outlet inside of this container into which the dialog content will be loaded. */

--- a/src/angular/overlay/overlay-container.ts
+++ b/src/angular/overlay/overlay-container.ts
@@ -33,7 +33,7 @@ import { SbbOverlayConfig } from './overlay-config';
 })
 export class SbbOverlayContainer extends SbbOverlayContainerBase<SbbOverlay> {
   readonly _config: SbbOverlayConfig<SbbOverlayContainer> =
-    inject(SbbOverlayConfig, { optional: true }) || {};
+    inject(SbbOverlayConfig<SbbOverlayContainer>, { optional: true }) || {};
 
   /** The portal outlet inside of this container into which the dialog content will be loaded. */
   public elementInstance = inject(SbbOverlay);

--- a/src/angular/overlay/overlay-ref.ts
+++ b/src/angular/overlay/overlay-ref.ts
@@ -1,4 +1,4 @@
-import { SbbOverlayBaseRef } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseRef } from '@sbb-esta/lyne-angular/core';
 import type { SbbOverlayCloseEvent } from '@sbb-esta/lyne-elements/overlay.pure.js';
 
 export class SbbOverlayRef<T = unknown, R = unknown> extends SbbOverlayBaseRef<

--- a/src/angular/overlay/overlay-service.ts
+++ b/src/angular/overlay/overlay-service.ts
@@ -3,7 +3,7 @@ import { inject, Service, type TemplateRef } from '@angular/core';
 import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core';
 
 import type { SbbOverlay } from './overlay';
-import type { SbbOverlayConfig } from './overlay-config';
+import { SbbOverlayConfig } from './overlay-config';
 import { SbbOverlayContainer } from './overlay-container';
 import { SbbOverlayRef } from './overlay-ref';
 
@@ -15,7 +15,8 @@ export class SbbOverlayService extends SbbOverlayBaseService<
 > {
   protected parentService = inject(SbbOverlayService, { optional: true, skipSelf: true });
   protected containerType = SbbOverlayContainer;
-  protected overlayRefConstructor = SbbOverlayRef;
+  protected refConstructor = SbbOverlayRef;
+  protected configType = SbbOverlayConfig;
 
   public override open<T = unknown, R = unknown>(
     componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,

--- a/src/angular/overlay/overlay-service.ts
+++ b/src/angular/overlay/overlay-service.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from '@angular/cdk/overlay';
 import { inject, Service, type TemplateRef } from '@angular/core';
-import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core';
 
 import type { SbbOverlay } from './overlay';
 import type { SbbOverlayConfig } from './overlay-config';

--- a/src/angular/overlay/overlay-service.ts
+++ b/src/angular/overlay/overlay-service.ts
@@ -1,8 +1,9 @@
 import type { ComponentType } from '@angular/cdk/overlay';
 import { inject, Service, type TemplateRef } from '@angular/core';
-import { SbbOverlayBaseService, type SbbOverlayConfig } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core/overlay';
 
 import type { SbbOverlay } from './overlay';
+import type { SbbOverlayConfig } from './overlay-config';
 import { SbbOverlayContainer } from './overlay-container';
 import { SbbOverlayRef } from './overlay-ref';
 
@@ -18,7 +19,7 @@ export class SbbOverlayService extends SbbOverlayBaseService<
 
   public override open<T = unknown, R = unknown>(
     componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-    config?: SbbOverlayConfig<SbbOverlayContainer, SbbOverlay>,
+    config?: SbbOverlayConfig<SbbOverlayContainer>,
   ): SbbOverlayRef<T, R> {
     return super.open(componentOrTemplateRef, config) as SbbOverlayRef<T, R>;
   }

--- a/src/angular/overlay/overlay.module.ts
+++ b/src/angular/overlay/overlay.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core';
 
 import { SbbOverlay } from './overlay';
 import { SbbOverlayClose } from './overlay-close/overlay-close';

--- a/src/angular/overlay/overlay.spec.ts
+++ b/src/angular/overlay/overlay.spec.ts
@@ -11,7 +11,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
-import { SBB_OVERLAY_DATA } from '@sbb-esta/lyne-angular/core/overlay';
+import { SBB_OVERLAY_DATA } from '@sbb-esta/lyne-angular/core';
 
 import { SbbOverlay } from './overlay';
 import { SbbOverlayRef } from './overlay-ref';

--- a/src/angular/popover/popover.module.ts
+++ b/src/angular/popover/popover.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core';
 
 import { SbbPopover } from './popover/popover';
 import { SbbPopoverClose } from './popover-close/popover-close';

--- a/src/angular/sidebar/sidebar.module.ts
+++ b/src/angular/sidebar/sidebar.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbFocusInitial } from '@sbb-esta/lyne-angular/core';
 
 import { SbbSidebar } from './sidebar/sidebar';
 import { SbbSidebarCloseButton } from './sidebar-close-button/sidebar-close-button';

--- a/src/angular/toast/index.ts
+++ b/src/angular/toast/index.ts
@@ -1,6 +1,7 @@
 export * from './simple-toast';
 export * from './toast';
 export * from './toast-close/toast-close';
+export * from './toast-config';
 export * from './toast-container';
 export * from './toast-ref';
 export * from './toast-service';

--- a/src/angular/toast/simple-toast.ts
+++ b/src/angular/toast/simple-toast.ts
@@ -1,5 +1,5 @@
 import { Component, inject, ViewEncapsulation } from '@angular/core';
-import { SBB_OVERLAY_DATA } from '@sbb-esta/lyne-angular/core/overlay';
+import { SBB_OVERLAY_DATA } from '@sbb-esta/lyne-angular/core';
 
 /**
  * A component used to open as the default toast, matching digital.sbb.ch spec.

--- a/src/angular/toast/toast-config.ts
+++ b/src/angular/toast/toast-config.ts
@@ -1,0 +1,10 @@
+import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core/overlay';
+
+import type { SbbToast } from './toast';
+import type { SbbToastContainer } from './toast-container';
+
+export class SbbToastConfig<
+  C extends SbbToastContainer,
+  I = SbbToast,
+  D = unknown,
+> extends SbbOverlayBaseConfig<C, I, D> {}

--- a/src/angular/toast/toast-config.ts
+++ b/src/angular/toast/toast-config.ts
@@ -1,4 +1,4 @@
-import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core';
 
 import type { SbbToast } from './toast';
 import type { SbbToastContainer } from './toast-container';

--- a/src/angular/toast/toast-config.ts
+++ b/src/angular/toast/toast-config.ts
@@ -1,3 +1,5 @@
+import type { StaticProvider } from '@angular/core';
+import type { SbbOverlayBaseRef } from '@sbb-esta/lyne-angular/core';
 import { SbbOverlayBaseConfig } from '@sbb-esta/lyne-angular/core';
 
 import type { SbbToast } from './toast';
@@ -7,4 +9,16 @@ export class SbbToastConfig<
   C extends SbbToastContainer,
   I = SbbToast,
   D = unknown,
-> extends SbbOverlayBaseConfig<C, I, D> {}
+> extends SbbOverlayBaseConfig<C, I, D> {
+  /**
+   * Providers that will be exposed to the contents of the dialog. Can also
+   * be provided as a function in order to generate the providers lazily.
+   */
+  declare providers?:
+    | StaticProvider[]
+    | ((
+        overlayRef: SbbOverlayBaseRef,
+        config: SbbToastConfig<C, I, D>,
+        container: C,
+      ) => StaticProvider[]);
+}

--- a/src/angular/toast/toast-container.ts
+++ b/src/angular/toast/toast-container.ts
@@ -7,7 +7,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { outputToObservable } from '@angular/core/rxjs-interop';
-import { SbbOverlayContainerBase, SbbOverlayState } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayContainerBase, SbbOverlayState } from '@sbb-esta/lyne-angular/core';
 import type { Observable } from 'rxjs';
 
 import { SbbToast } from './toast';

--- a/src/angular/toast/toast-container.ts
+++ b/src/angular/toast/toast-container.ts
@@ -7,14 +7,11 @@ import {
   viewChild,
 } from '@angular/core';
 import { outputToObservable } from '@angular/core/rxjs-interop';
-import {
-  SbbOverlayConfig,
-  SbbOverlayContainerBase,
-  SbbOverlayState,
-} from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayContainerBase, SbbOverlayState } from '@sbb-esta/lyne-angular/core/overlay';
 import type { Observable } from 'rxjs';
 
 import { SbbToast } from './toast';
+import { SbbToastConfig } from './toast-config';
 
 /**
  * Container component for `SbbToast` components.
@@ -34,8 +31,8 @@ import { SbbToast } from './toast';
   template: `<ng-template cdkPortalOutlet></ng-template>`,
 })
 export class SbbToastContainer extends SbbOverlayContainerBase<SbbToast> {
-  readonly _config: SbbOverlayConfig<SbbToastContainer, SbbToast, unknown> =
-    inject(SbbOverlayConfig, { optional: true }) || {};
+  readonly _config: SbbToastConfig<SbbToastContainer> =
+    inject(SbbToastConfig, { optional: true }) || {};
 
   /** The portal outlet inside of this container into which the dialog content will be loaded. */
   public elementInstance = inject(SbbToast);

--- a/src/angular/toast/toast-container.ts
+++ b/src/angular/toast/toast-container.ts
@@ -32,7 +32,7 @@ import { SbbToastConfig } from './toast-config';
 })
 export class SbbToastContainer extends SbbOverlayContainerBase<SbbToast> {
   readonly _config: SbbToastConfig<SbbToastContainer> =
-    inject(SbbToastConfig, { optional: true }) || {};
+    inject(SbbToastConfig<SbbToastContainer>, { optional: true }) || {};
 
   /** The portal outlet inside of this container into which the dialog content will be loaded. */
   public elementInstance = inject(SbbToast);

--- a/src/angular/toast/toast-ref.ts
+++ b/src/angular/toast/toast-ref.ts
@@ -1,3 +1,3 @@
-import { SbbOverlayBaseRef } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseRef } from '@sbb-esta/lyne-angular/core';
 
 export class SbbToastRef<T = unknown> extends SbbOverlayBaseRef<T> {}

--- a/src/angular/toast/toast-service.ts
+++ b/src/angular/toast/toast-service.ts
@@ -4,7 +4,7 @@ import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core';
 
 import { SbbSimpleToast } from './simple-toast';
 import type { SbbToast } from './toast';
-import type { SbbToastConfig } from './toast-config';
+import { SbbToastConfig } from './toast-config';
 import { SbbToastContainer } from './toast-container';
 import { SbbToastRef } from './toast-ref';
 
@@ -16,7 +16,8 @@ export class SbbToastService extends SbbOverlayBaseService<
 > {
   protected parentService = inject(SbbToastService, { optional: true, skipSelf: true });
   protected containerType = SbbToastContainer;
-  protected overlayRefConstructor = SbbToastRef;
+  protected refConstructor = SbbToastRef;
+  protected configType = SbbToastConfig;
 
   override open<T = unknown | SbbSimpleToast>(
     content: ComponentType<T> | TemplateRef<T> | string,

--- a/src/angular/toast/toast-service.ts
+++ b/src/angular/toast/toast-service.ts
@@ -1,10 +1,10 @@
 import type { ComponentType } from '@angular/cdk/overlay';
 import { inject, Service, type TemplateRef } from '@angular/core';
-import type { SbbOverlayConfig } from '@sbb-esta/lyne-angular/core/overlay';
 import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core/overlay';
 
 import { SbbSimpleToast } from './simple-toast';
 import type { SbbToast } from './toast';
+import type { SbbToastConfig } from './toast-config';
 import { SbbToastContainer } from './toast-container';
 import { SbbToastRef } from './toast-ref';
 
@@ -20,11 +20,11 @@ export class SbbToastService extends SbbOverlayBaseService<
 
   override open<T = unknown | SbbSimpleToast>(
     content: ComponentType<T> | TemplateRef<T> | string,
-    config?: SbbOverlayConfig<SbbToastContainer, SbbToast>,
+    config?: SbbToastConfig<SbbToastContainer>,
   ): SbbToastRef<T> {
     if (typeof content === 'string') {
       const message = content;
-      const configWithComponent: SbbOverlayConfig<SbbToastContainer, SbbToast> = {
+      const configWithComponent: SbbToastConfig<SbbToastContainer> = {
         ...config,
         data: { message, ...(config?.data || {}) },
       };

--- a/src/angular/toast/toast-service.ts
+++ b/src/angular/toast/toast-service.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from '@angular/cdk/overlay';
 import { inject, Service, type TemplateRef } from '@angular/core';
-import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core/overlay';
+import { SbbOverlayBaseService } from '@sbb-esta/lyne-angular/core';
 
 import { SbbSimpleToast } from './simple-toast';
 import type { SbbToast } from './toast';

--- a/src/angular/toast/toast.spec.ts
+++ b/src/angular/toast/toast.spec.ts
@@ -9,7 +9,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
-import { SBB_OVERLAY_DATA } from '@sbb-esta/lyne-angular/core/overlay';
+import { SBB_OVERLAY_DATA } from '@sbb-esta/lyne-angular/core';
 
 import { SbbToast } from './toast';
 import { SbbToastRef } from './toast-ref';

--- a/tsconfig.doc.json
+++ b/tsconfig.doc.json
@@ -1,9 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.spec.ts", "src/angular/core/*.ts", "src/angular/core/testing/*.ts"],
-  "include": [
-    "src/angular/**/*.ts",
-    "src/angular-experimental/**/*.ts",
-    "src/angular/core/overlay/*.ts"
-  ]
+  "exclude": ["src/**/*.spec.ts"],
+  "include": ["src/angular/**/*.ts", "src/angular-experimental/**/*.ts"]
 }


### PR DESCRIPTION
BREAKING CHANGE: introduced specific overlay configurations for dialog (SbbDialogConfig), overlay (SbbOverlayConfig) and toast (SbbToastConfig). Removed entry point `core/overlay`; use `core` instead.