### PR TITLE
refactor: remove obsolete  entry points for file selector

### DIFF
--- a/src/angular/file-selector/file-selector-dropzone/index.ts
+++ b/src/angular/file-selector/file-selector-dropzone/index.ts
@@ -1,1 +1,0 @@
-export * from './file-selector-dropzone';

--- a/src/angular/file-selector/file-selector-dropzone/ng-package.json
+++ b/src/angular/file-selector/file-selector-dropzone/ng-package.json
@@ -1,5 +1,0 @@
-{
-  "lib": {
-    "entryFile": "index.ts"
-  }
-}

--- a/src/angular/file-selector/file-selector.module.ts
+++ b/src/angular/file-selector/file-selector.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
-import { SbbFileSelector } from '@sbb-esta/lyne-angular/file-selector/file-selector';
-import { SbbFileSelectorDropzone } from '@sbb-esta/lyne-angular/file-selector/file-selector-dropzone';
+
+import { SbbFileSelector } from './file-selector/file-selector';
+import { SbbFileSelectorDropzone } from './file-selector-dropzone/file-selector-dropzone';
 
 const SBB_FILE_SELECTOR_EXPORTED_DECLARATIONS = [SbbFileSelector, SbbFileSelectorDropzone];
 

--- a/src/angular/file-selector/file-selector/index.ts
+++ b/src/angular/file-selector/file-selector/index.ts
@@ -1,1 +1,0 @@
-export * from './file-selector';

--- a/src/angular/file-selector/file-selector/ng-package.json
+++ b/src/angular/file-selector/file-selector/ng-package.json
@@ -1,5 +1,0 @@
-{
-  "lib": {
-    "entryFile": "index.ts"
-  }
-}


### PR DESCRIPTION
This removes the sub entry points for file selector and file selector dropzone. Both can be imported via `@sbb-esta/lyne-angular/file-selector`.