### PR TITLE
fix(tooltip): always load tooltip element

### DIFF
--- a/src/angular/expansion-panel/expansion-panel-content/expansion-panel-content-directive.ts
+++ b/src/angular/expansion-panel/expansion-panel-content/expansion-panel-content-directive.ts
@@ -1,4 +1,4 @@
-import { Directive, inject, InjectionToken, TemplateRef } from '@angular/core';
+import { Directive, forwardRef, inject, InjectionToken, TemplateRef } from '@angular/core';
 
 export const SBB_EXPANSION_PANEL_CONTENT = new InjectionToken<SbbExpansionPanelContentDirective>(
   'SbbExpansionPanelContentDirective',
@@ -7,7 +7,10 @@ export const SBB_EXPANSION_PANEL_CONTENT = new InjectionToken<SbbExpansionPanelC
 @Directive({
   selector: '[sbbExpansionPanelContent]',
   providers: [
-    { provide: SBB_EXPANSION_PANEL_CONTENT, useExisting: SbbExpansionPanelContentDirective },
+    {
+      provide: SBB_EXPANSION_PANEL_CONTENT,
+      useExisting: forwardRef(() => SbbExpansionPanelContentDirective),
+    },
   ],
 })
 export class SbbExpansionPanelContentDirective {

--- a/src/angular/stepper/step/step-content.ts
+++ b/src/angular/stepper/step/step-content.ts
@@ -1,10 +1,10 @@
-import { Directive, inject, InjectionToken, TemplateRef } from '@angular/core';
+import { Directive, forwardRef, inject, InjectionToken, TemplateRef } from '@angular/core';
 
 export const SBB_STEP_CONTENT = new InjectionToken<SbbStepContent>('SbbStepContent');
 
 @Directive({
   selector: '[sbbStepContent]',
-  providers: [{ provide: SBB_STEP_CONTENT, useExisting: SbbStepContent }],
+  providers: [{ provide: SBB_STEP_CONTENT, useExisting: forwardRef(() => SbbStepContent) }],
 })
 export class SbbStepContent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/angular/tabs/tab/tab-content.ts
+++ b/src/angular/tabs/tab/tab-content.ts
@@ -1,10 +1,10 @@
-import { Directive, inject, InjectionToken, TemplateRef } from '@angular/core';
+import { Directive, forwardRef, inject, InjectionToken, TemplateRef } from '@angular/core';
 
 export const SBB_TAB_CONTENT = new InjectionToken<SbbTabContent>('SbbTabContent');
 
 @Directive({
   selector: '[sbbTabContent]',
-  providers: [{ provide: SBB_TAB_CONTENT, useExisting: SbbTabContent }],
+  providers: [{ provide: SBB_TAB_CONTENT, useExisting: forwardRef(() => SbbTabContent) }],
 })
 export class SbbTabContent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/angular/tooltip/tooltip-directives.ts
+++ b/src/angular/tooltip/tooltip-directives.ts
@@ -1,18 +1,19 @@
 import { Directive, ElementRef, inject, Input, numberAttribute } from '@angular/core';
+import { SbbTooltipElement } from '@sbb-esta/lyne-elements/tooltip.pure.js';
 
 @Directive({
   selector: '[sbb-tooltip]',
 })
 export class SbbTooltipDirective {
+  static {
+    SbbTooltipElement.define();
+  }
+
   #elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
   @Input('sbb-tooltip')
   public set tooltip(value: string | null) {
-    if (value) {
-      this.#elementRef.nativeElement.setAttribute('sbb-tooltip', value);
-    } else {
-      this.#elementRef.nativeElement.removeAttribute('sbb-tooltip');
-    }
+    this.#assignAttribute('sbb-tooltip', value);
   }
   public get tooltip(): string | null {
     return this.#elementRef.nativeElement.getAttribute('sbb-tooltip');
@@ -20,11 +21,7 @@ export class SbbTooltipDirective {
 
   @Input({ alias: 'sbb-tooltip-open-delay', transform: numberAttribute })
   public set openDelay(value: number | null) {
-    if (value !== null && !isNaN(value) && value >= 0) {
-      this.#elementRef.nativeElement.setAttribute('sbb-tooltip-open-delay', String(value));
-    } else {
-      this.#elementRef.nativeElement.removeAttribute('sbb-tooltip-open-delay');
-    }
+    this.#assignNumberAttribute('sbb-tooltip-open-delay', value);
   }
   public get openDelay(): number {
     return Number(this.#elementRef.nativeElement.getAttribute('sbb-tooltip-open-delay'));
@@ -32,11 +29,7 @@ export class SbbTooltipDirective {
 
   @Input({ alias: 'sbb-tooltip-close-delay', transform: numberAttribute })
   public set closeDelay(value: number | null) {
-    if (value !== null && !isNaN(value) && value >= 0) {
-      this.#elementRef.nativeElement.setAttribute('sbb-tooltip-close-delay', String(value));
-    } else {
-      this.#elementRef.nativeElement.removeAttribute('sbb-tooltip-close-delay');
-    }
+    this.#assignNumberAttribute('sbb-tooltip-close-delay', value);
   }
   public get closeDelay(): number {
     return Number(this.#elementRef.nativeElement.getAttribute('sbb-tooltip-close-delay'));
@@ -44,13 +37,25 @@ export class SbbTooltipDirective {
 
   @Input({ alias: 'sbb-tooltip-position' })
   public set position(value: string | null) {
-    if (value) {
-      this.#elementRef.nativeElement.setAttribute('sbb-tooltip-position', value);
-    } else {
-      this.#elementRef.nativeElement.removeAttribute('sbb-tooltip-position');
-    }
+    this.#assignAttribute('sbb-tooltip-position', value);
   }
   public get position(): string | null {
     return this.#elementRef.nativeElement.getAttribute('sbb-tooltip-position');
+  }
+
+  #assignAttribute(name: string, value: string | null): void {
+    if (value) {
+      this.#elementRef.nativeElement.setAttribute(name, value);
+    } else {
+      this.#elementRef.nativeElement.removeAttribute(name);
+    }
+  }
+
+  #assignNumberAttribute(name: string, value: number | null): void {
+    if (value !== null && !isNaN(value) && value >= 0) {
+      this.#elementRef.nativeElement.setAttribute(name, String(value));
+    } else {
+      this.#elementRef.nativeElement.removeAttribute(name);
+    }
   }
 }


### PR DESCRIPTION
The tooltip directive requires the tooltip element to function. This was currently not guaranteed to be loaded, so this PR addresses this.