### PR TITLE
docs(alert): remove checkbox-group group from variant example

### DIFF
--- a/src/docs/app/angular/examples/alert/alert-variants/alert-variants-example.html
+++ b/src/docs/app/angular/examples/alert/alert-variants/alert-variants-example.html
@@ -27,7 +27,5 @@
   </sbb-radio-button-group>
 
   <label for="readonly">Readonly</label>
-  <sbb-checkbox-group>
-    <sbb-checkbox id="readonly" [formField]="controls.readOnly"></sbb-checkbox>
-  </sbb-checkbox-group>
+  <sbb-checkbox id="readonly" [formField]="controls.readOnly"></sbb-checkbox>
 </div>


### PR DESCRIPTION
The `sbb-checkbox-group` is no longer needed in the variant example table since the style handles it.