### PR TITLE
feat(form-field): implement support for Signal Forms

### DIFF
--- a/src/angular/form-field/form-field/form-field-control.ts
+++ b/src/angular/form-field/form-field/form-field-control.ts
@@ -16,6 +16,10 @@ export abstract class SbbFormFieldControl implements SbbFormFieldElementControl 
   abstract readonly disabled: boolean;
   /** Whether the control is readonly. */
   abstract readonly readOnly?: boolean;
+  /** Whether the control has been interacted with. */
+  abstract readonly interacted?: boolean;
+  /** Whether the control is invalid. */
+  abstract readonly invalid?: boolean;
 
   /** Handles a click on the control's container. */
   abstract onContainerClick(event: MouseEvent): void;

--- a/src/angular/form-field/form-field/form-field.spec.ts
+++ b/src/angular/form-field/form-field/form-field.spec.ts
@@ -1,8 +1,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Component, ElementRef, forwardRef, viewChild } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  forwardRef,
+  inject,
+  input,
+  model,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import type { ControlValueAccessor } from '@angular/forms';
 import { FormControl, NG_VALUE_ACCESSOR, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  disabled,
+  form,
+  FormField,
+  readonly,
+  required,
+  type FormValueControl,
+} from '@angular/forms/signals';
 import { Subject } from 'rxjs';
 
 import { SbbFormField } from './form-field';
@@ -46,6 +64,11 @@ describe('sbb-form-field', () => {
     let fixture: ComponentFixture<CustomControlTestComponent>,
       component: CustomControlTestComponent;
 
+    const hasState = (state: string): boolean =>
+      (fixture.nativeElement as HTMLElement)
+        .querySelector('sbb-form-field')!
+        .matches(`:state(${state})`);
+
     beforeEach(async () => {
       fixture = TestBed.createComponent(CustomControlTestComponent);
       component = fixture.componentInstance;
@@ -80,11 +103,7 @@ describe('sbb-form-field', () => {
       input.disabled = true;
       input.stateChanges.next();
       await fixture.whenStable();
-      expect(
-        (fixture.nativeElement as HTMLElement)
-          .querySelector('sbb-form-field')!
-          .matches(':state(disabled)'),
-      ).toBeTruthy();
+      expect(hasState('disabled')).toBeTruthy();
     });
 
     it('should reflect changed empty state', async () => {
@@ -92,11 +111,7 @@ describe('sbb-form-field', () => {
       input.empty = true;
       input.stateChanges.next();
       await fixture.whenStable();
-      expect(
-        (fixture.nativeElement as HTMLElement)
-          .querySelector('sbb-form-field')!
-          .matches(':state(empty)'),
-      ).toBeTruthy();
+      expect(hasState('empty')).toBeTruthy();
     });
 
     it('should reflect changed readOnly state', async () => {
@@ -104,11 +119,7 @@ describe('sbb-form-field', () => {
       input.readOnly = true;
       input.stateChanges.next();
       await fixture.whenStable();
-      expect(
-        (fixture.nativeElement as HTMLElement)
-          .querySelector('sbb-form-field')!
-          .matches(':state(readonly)'),
-      ).toBeTruthy();
+      expect(hasState('readonly')).toBeTruthy();
     });
 
     it('should focus the inner input with onContainerClick', async () => {
@@ -116,6 +127,83 @@ describe('sbb-form-field', () => {
       const focusSpy = vi.spyOn(input.input()!.nativeElement!, 'focus');
       input.onContainerClick(new MouseEvent('click'));
       expect(focusSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('signal custom control', () => {
+    let fixture: ComponentFixture<SignalCustomControlTestComponent>,
+      component: SignalCustomControlTestComponent;
+
+    const hasState = (state: string): boolean =>
+      (fixture.nativeElement as HTMLElement)
+        .querySelector('sbb-form-field')!
+        .matches(`:state(${state})`);
+
+    beforeEach(async () => {
+      fixture = TestBed.createComponent(SignalCustomControlTestComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', async () => {
+      expect(component).toBeDefined();
+    });
+
+    it('should detect invalid state', async () => {
+      component.input()!.touch.emit();
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const formField = component.formField();
+      const state = formField.state();
+
+      expect(state.invalid()).toBe(true);
+      expect(state.touched()).toBe(true);
+
+      // Wait for attribute observer to run
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(
+        getComputedStyle(
+          (fixture.nativeElement as HTMLElement).querySelector('sbb-form-field')!,
+        ).getPropertyValue('--sbb-form-field-border-color'),
+      ).toBe('light-dark(#c60018, #ff3838)');
+    });
+
+    it('should reflect changed disabled state', async () => {
+      component.disabled.set(true);
+      await fixture.whenStable();
+      expect(hasState('disabled')).toBeTruthy();
+      component.disabled.set(false);
+      await fixture.whenStable();
+      expect(hasState('disabled')).toBeFalsy();
+    });
+
+    it('should reflect changed empty state', async () => {
+      await fixture.whenStable();
+      expect(hasState('empty')).toBeTruthy();
+      component.control().value.set('value');
+      await fixture.whenStable();
+      expect(hasState('empty')).toBeFalsy();
+    });
+
+    it('should reflect changed readOnly state', async () => {
+      component.readonly.set(true);
+      await fixture.whenStable();
+      expect(hasState('readonly')).toBeTruthy();
+      component.readonly.set(false);
+      await fixture.whenStable();
+      expect(hasState('readonly')).toBeFalsy();
+    });
+
+    it('should focus the inner input with onContainerClick', async () => {
+      const formField = component.formField();
+      formField.focus();
+
+      const focusedElement = document.activeElement;
+      expect(focusedElement).toBeDefined();
+      expect(focusedElement).toHaveClass('sbb-signal-custom-control-span');
     });
   });
 });
@@ -181,6 +269,7 @@ class CustomControlComponent implements SbbFormFieldControl, ControlValueAccesso
 }
 
 @Component({
+  selector: 'sbb-custom-control-test',
   template: `<sbb-form-field
     ><sbb-custom-control [formControl]="control" #input
   /></sbb-form-field>`,
@@ -189,4 +278,40 @@ class CustomControlComponent implements SbbFormFieldControl, ControlValueAccesso
 class CustomControlTestComponent {
   control = new FormControl('', Validators.required);
   input = viewChild<CustomControlComponent>('input');
+}
+
+@Component({
+  selector: 'sbb-signal-custom-control',
+  template: `<span class="sbb-signal-custom-control-span" tabindex="0">{{ value() }}</span>`,
+})
+class SignalCustomControlComponent implements FormValueControl<string> {
+  #element = inject(ElementRef<HTMLElement>);
+  value = model('');
+  disabled = input(false);
+  readonly = input(false);
+  touched = input(false);
+  touch = output();
+
+  focus?(options?: FocusOptions): void {
+    this.#element.nativeElement.querySelector('.sbb-signal-custom-control-span')?.focus(options);
+  }
+}
+
+@Component({
+  selector: 'sbb-signal-custom-control-test',
+  template: `<sbb-form-field
+    ><sbb-signal-custom-control [formField]="control" #input
+  /></sbb-form-field>`,
+  imports: [SbbFormField, SignalCustomControlComponent, FormField],
+})
+class SignalCustomControlTestComponent {
+  input = viewChild<SignalCustomControlComponent>('input');
+  formField = viewChild.required(FormField<string>);
+  disabled = signal(false);
+  readonly = signal(false);
+  control = form(signal(''), (s) => {
+    required(s);
+    disabled(s, { when: this.disabled });
+    readonly(s, { when: this.readonly });
+  });
 }

--- a/src/angular/form-field/form-field/form-field.ts
+++ b/src/angular/form-field/form-field/form-field.ts
@@ -1,22 +1,22 @@
 import {
-  afterNextRender,
   contentChild,
+  DestroyRef,
   Directive,
+  effect,
   ElementRef,
-  EnvironmentInjector,
   inject,
   Input,
+  isSignal,
   NgZone,
-  runInInjectionContext,
 } from '@angular/core';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { FormField } from '@angular/forms/signals';
 import { booleanAttribute } from '@sbb-esta/lyne-angular/core';
 import {
   SbbFormFieldControlEvent,
   SbbFormFieldElement,
+  type SbbFormFieldElementControl,
 } from '@sbb-esta/lyne-elements/form-field.pure.js';
-import { of } from 'rxjs';
-import { startWith, switchMap } from 'rxjs/operators';
+import { type Subscription } from 'rxjs';
 
 import { SbbFormFieldControl } from './form-field-control';
 
@@ -43,30 +43,55 @@ export class SbbFormField {
 
   #element: ElementRef<SbbFormFieldElement> = inject(ElementRef<SbbFormFieldElement>);
   #ngZone: NgZone = inject(NgZone);
-  #environmentInjector = inject(EnvironmentInjector);
+  #stateChangesSubscription = new Map<SbbFormFieldControl, Subscription>();
   // Must not be ES private, as Angular does not support this for contentChild.
   private control = contentChild(SbbFormFieldControl, { descendants: true });
+  private formField = contentChild(FormField, { descendants: true });
 
   constructor() {
-    afterNextRender(() => {
-      // To support custom controls, we query for an optional implementation
-      // of the SbbFormFieldControl, which we then use to dispatch an
-      // SbbFormFieldControlEvent event whenever the custom control has a
-      // state change.
-      runInInjectionContext(this.#environmentInjector, () => {
-        toObservable(this.control)
-          .pipe(
-            switchMap((control) =>
-              !control ? of(null!) : control.stateChanges.pipe(startWith(null)),
-            ),
-            takeUntilDestroyed(),
-          )
-          .subscribe(() =>
-            this.#element.nativeElement?.dispatchEvent(
-              new SbbFormFieldControlEvent(this.control() ?? null),
-            ),
+    // To support custom controls, we query for an optional implementation
+    // of the SbbFormFieldControl, which we then use to dispatch an
+    // SbbFormFieldControlEvent event whenever the custom control has a
+    // state change.
+    inject(DestroyRef).onDestroy(() => this.#unsubscribeStateChanges());
+    const emptyValues = [undefined, null, ''];
+    effect(() => {
+      const control = this.control();
+      if (control) {
+        if (!this.#stateChangesSubscription.has(control)) {
+          this.#unsubscribeStateChanges();
+          this.#stateChangesSubscription.set(
+            control,
+            control.stateChanges.subscribe(() => this.#dispatchControlEvent(control)),
           );
-      });
+        }
+        return;
+      }
+
+      const formField = this.formField();
+      const state = formField?.state();
+      if (!formField || !state) {
+        this.#dispatchControlEvent(null);
+        return;
+      }
+
+      const element = formField.element;
+      const type =
+        ('type' in state ? (isSignal(state.type) ? state.type() : state.type) : undefined) ??
+        (element as unknown as { type: string }).type;
+
+      this.#element.nativeElement?.dispatchEvent(
+        new SbbFormFieldControlEvent({
+          element,
+          disabled: state.disabled(),
+          empty: emptyValues.includes(state.controlValue()),
+          readOnly: state.readonly(),
+          type: type ? String(type) : undefined,
+          invalid: state.invalid(),
+          interacted: state.touched(),
+          onContainerClick: () => formField.focus(),
+        }),
+      );
     });
   }
 
@@ -177,5 +202,14 @@ export class SbbFormField {
    */
   public get label(): HTMLLabelElement | null {
     return this.#element.nativeElement.label;
+  }
+
+  #dispatchControlEvent(control: SbbFormFieldElementControl | null): void {
+    this.#element.nativeElement?.dispatchEvent(new SbbFormFieldControlEvent(control));
+  }
+
+  #unsubscribeStateChanges(): void {
+    this.#stateChangesSubscription.forEach((s) => s.unsubscribe());
+    this.#stateChangesSubscription.clear();
   }
 }

--- a/src/angular/form-field/readme.md
+++ b/src/angular/form-field/readme.md
@@ -265,8 +265,16 @@ needs to be dispatched on the `<sbb-form-field>` instance.
 
 <!-- #region override custom-form-control-angular -->
 
-In order for `<sbb-form-field>` to support a custom form component, you need to implement
-the `SbbFormFieldControl` interface and register it as a provider.
+`<sbb-form-field>` supports creating custom form controls.
+
+#### Signal Forms
+
+With version 22.2.0 of `@sbb-esta/lyne-angular` this will simply work out of the box
+if you implement the Angular `FormValueControl` interface.
+
+#### Reactive & Model driven Forms
+
+You will need to implement the `SbbFormFieldControl` interface and register it as a provider.
 Important to note is that the `stateChanges` observable MUST emit whenever
 one of the properties defined in `SbbFormFieldControl` changes.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,17 +2148,17 @@
   integrity sha512-l1In9Sq/jf5Smsphr4LtYndGtpi3VJjrVA2qpnBLVNZyh6Tyg/2Uzj8XZ71WAje8NSw1J4rlyJ3yF2JHZuIH5w==
 
 "@sbb-esta/lyne-elements-experimental@npm:@sbb-esta/lyne-elements-experimental-dev@v5-dev":
-  version "5.4.0-dev.1784558333"
-  resolved "https://registry.yarnpkg.com/@sbb-esta/lyne-elements-experimental-dev/-/lyne-elements-experimental-dev-5.4.0-dev.1784558333.tgz#86ee35046103ee2c9d22b0e71e822df867a00fdf"
-  integrity sha512-TkJdW8VD/cA8c2UIfqqzMza6S77SwEu2V8DiQnERjdnmM0Uc68jIgX64fZdmZutpgIt5UxeT/RBPIXKc6Ao04Q==
+  version "5.4.0-dev.1784644052"
+  resolved "https://registry.yarnpkg.com/@sbb-esta/lyne-elements-experimental-dev/-/lyne-elements-experimental-dev-5.4.0-dev.1784644052.tgz#973e91713b2e2f46c413e945771f062e3f04b266"
+  integrity sha512-8QuCr6bZHaLlQLJQE6nEd2Klpo+yZy7AhWj/KgAgWMXTk7JvfdLNnO8a1RoKQvkDP9FSwADPW3rnp7oJnclMSg==
   dependencies:
     lit "^3.3.3"
     tslib "^2.8.1"
 
 "@sbb-esta/lyne-elements@npm:@sbb-esta/lyne-elements-dev@v5-dev":
-  version "5.4.0-dev.1784558321"
-  resolved "https://registry.yarnpkg.com/@sbb-esta/lyne-elements-dev/-/lyne-elements-dev-5.4.0-dev.1784558321.tgz#d113c0607459a91c7dd1d0aeda716d0db184c7f1"
-  integrity sha512-pBovKpAgNb3UaYWbUp208p0G8LRbTRaM2+SLaQUW0BSv6+JP3yp3LwTBMoIoaCwW8vk+sswL+Gxhg0DIYNWBFw==
+  version "5.4.0-dev.1784644043"
+  resolved "https://registry.yarnpkg.com/@sbb-esta/lyne-elements-dev/-/lyne-elements-dev-5.4.0-dev.1784644043.tgz#10f5884bd795658f56b27b5199b932ae908809e9"
+  integrity sha512-IW7otUAD61lJatlKczNO+XBrVJLNV83+BnMUKNBQa912oBV2c7A+HCJL2niD1m6H9YB/R9XrLcByI1aTDLFRog==
   dependencies:
     "@lit-labs/observers" "^2.1.0"
     lit "^3.3.3"


### PR DESCRIPTION
This PR adds support for custom form controls with `FormValueControl`.
When using Signal Forms, no additional integration is now necessary.