### PR TITLE
feat(dialog): add dimensions in SbbDialogConfig

### DIFF
--- a/src/angular/core/overlay/overlay-base.ts
+++ b/src/angular/core/overlay/overlay-base.ts
@@ -33,10 +33,124 @@ export abstract class SbbOverlayBaseService<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   R extends SbbOverlayBaseRef<any> = SbbOverlayBaseRef<any>,
 > implements OnDestroy {
-  #openOverlaysAtThisLevel: R[] = [];
+  /**
+   * Stream that emits when all open overlays have finished closing.
+   * Will emit on subscribe if there are no open overlays to begin with.
+   */
+  readonly afterAllClosed: Observable<void> = defer(
+    () =>
+      this.openOverlays.length
+        ? this.#getAfterAllClosed()
+        : this.#getAfterAllClosed().pipe(startWith(undefined)),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) as Observable<any>;
+
+  protected abstract parentService: SbbOverlayBaseService<C, I, R> | null;
+  protected abstract containerType: Type<C>;
+  protected abstract refConstructor: Type<R>;
+  protected abstract configType: Type<unknown>;
+  protected overlayDataToken: InjectionToken<unknown> = SBB_OVERLAY_DATA;
+
   readonly #afterAllClosedAtThisLevel = new Subject<void>();
   readonly #afterOpenedAtThisLevel = new Subject<R>();
+
+  #openOverlaysAtThisLevel: R[] = [];
   #idGenerator = inject(_IdGenerator);
+  #injector = inject(Injector);
+
+  protected constructor() {
+    /* empty */
+  }
+
+  /** Keeps track of the currently-open overlays. */
+  get openOverlays(): R[] {
+    return this.parentService ? this.parentService.openOverlays : this.#openOverlaysAtThisLevel;
+  }
+
+  /** Stream that emits when an overlay has been opened. */
+  get afterOpened(): Subject<R> {
+    return this.parentService ? this.parentService.afterOpened : this.#afterOpenedAtThisLevel;
+  }
+
+  open<T = unknown>(
+    componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
+    config: SbbOverlayBaseConfig<C, I> = {},
+  ): SbbOverlayBaseRef<T> {
+    config.id = config.id || this.#idGenerator.getId('cdk-overlay-');
+
+    if (
+      config.id &&
+      this.getOverlayById(config.id) &&
+      (typeof ngDevMode === 'undefined' || ngDevMode)
+    ) {
+      throw Error(`Overlay with id "${config.id}" exists already. The overlay id must be unique.`);
+    }
+
+    const overlayContainerElement = this.#injector.get(OverlayContainer).getContainerElement();
+
+    // Additional element is needed as DomPortalOutlet would remove the overlayContainerElement element on dispose.
+    // We must not remove the entire overlay container as it is considered living forever after first instantiation.
+    const host = this.#injector.get(DOCUMENT).createElement('div');
+    overlayContainerElement.appendChild(host);
+
+    const portalOutlet = new DomPortalOutlet(
+      host,
+      this.#injector.get(ApplicationRef),
+      this.#injector,
+    );
+    const overlayContainer = this.#attachContainer(portalOutlet, config);
+
+    const overlayRefConstructed = new this.refConstructor(
+      overlayContainer,
+      config,
+      portalOutlet,
+      this.#injector.get(Location),
+    );
+
+    this.#attachContent(componentOrTemplateRef, overlayRefConstructed, overlayContainer, config);
+
+    this.openOverlays.push(overlayRefConstructed);
+    this.afterOpened.next(overlayRefConstructed);
+
+    overlayRefConstructed.afterClosed.subscribe(() =>
+      this.#removeOpenOverlay(overlayRefConstructed, true),
+    );
+
+    overlayContainer.open();
+
+    return overlayRefConstructed;
+  }
+
+  /**
+   * Finds an open overlay by its id.
+   * @param id ID to use when looking up the overlay.
+   */
+  getOverlayById(id: string): R | undefined {
+    return this.openOverlays.find((overlay) => overlay.id === id);
+  }
+
+  /**
+   * Closes all currently-open overlays.
+   */
+  closeAll(): void {
+    // We have to copy the array first as the array is mutated during the iteration.
+    this.openOverlays.slice().forEach((ref: R) => ref.close());
+  }
+
+  ngOnDestroy() {
+    // Make a second pass and close the remaining dialogs. We do this second pass in order to
+    // correctly dispatch the `afterAllClosed` event in case we have a mixed array of dialogs
+    // that should be closed and dialogs that should not.
+    this.#openOverlaysAtThisLevel.reverse().forEach((dialog) => dialog.close());
+    this.#afterAllClosedAtThisLevel.complete();
+    this.#afterOpenedAtThisLevel.complete();
+    this.#openOverlaysAtThisLevel = [];
+  }
+
+  /** Method meant to be overridden by derived class (e.g. dialog) to configure the element after attaching it. */
+  protected configureContainer(_element: HTMLElement, _config: SbbOverlayBaseConfig<C, I>): void {
+    // no-op
+  }
 
   #createInjector<D>(
     config: SbbOverlayBaseConfig<C, I, D>,
@@ -78,7 +192,7 @@ export abstract class SbbOverlayBaseService<
     );
     const componentRef = portalOutlet.attach(containerPortal);
 
-    const ngZone = this.#injector.get(NgZone);
+    this.configureContainer(componentRef.location.nativeElement, config);
 
     if (typeof componentRef?.onDestroy === 'function') {
       // In most cases we control the portal and we know when it is being detached so that
@@ -88,6 +202,7 @@ export abstract class SbbOverlayBaseService<
       // reattach the overlay at a later point. It also has the advantage of waiting for animations.
       componentRef.onDestroy(() => {
         if (portalOutlet.hasAttached()) {
+          const ngZone = this.#injector.get(NgZone);
           // We have to delay the `detach` call, because detaching immediately prevents
           // other destroy hooks from running. This is likely a framework bug similar to
           // https://github.com/angular/angular/issues/46119
@@ -143,118 +258,9 @@ export abstract class SbbOverlayBaseService<
     }
   }
 
-  open<T = unknown>(
-    componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-    config: SbbOverlayBaseConfig<C, I> = {},
-  ): SbbOverlayBaseRef<T> {
-    config.id = config.id || this.#idGenerator.getId('cdk-overlay-');
-
-    if (
-      config.id &&
-      this.getOverlayById(config.id) &&
-      (typeof ngDevMode === 'undefined' || ngDevMode)
-    ) {
-      throw Error(`Overlay with id "${config.id}" exists already. The overlay id must be unique.`);
-    }
-
-    const overlayContainerElement = this.#injector.get(OverlayContainer).getContainerElement();
-
-    // Additional element is needed as DomPortalOutlet would remove the overlayContainerElement element on
-    // dispose. We must not remove the entire overlay container as it is considered living forever after first instantiation.
-    const host = this.#injector.get(DOCUMENT).createElement('div');
-    overlayContainerElement.appendChild(host);
-
-    const portalOutlet = new DomPortalOutlet(
-      host,
-      this.#injector.get(ApplicationRef),
-      this.#injector,
-    );
-    const overlayContainer = this.#attachContainer(portalOutlet, config);
-
-    const overlayRefConstructed = new this.refConstructor(
-      overlayContainer,
-      config,
-      portalOutlet,
-      this.#injector.get(Location),
-    );
-
-    this.#attachContent(componentOrTemplateRef, overlayRefConstructed, overlayContainer, config);
-
-    this.openOverlays.push(overlayRefConstructed);
-    this.afterOpened.next(overlayRefConstructed);
-
-    overlayRefConstructed.afterClosed.subscribe(() =>
-      this.#removeOpenOverlay(overlayRefConstructed, true),
-    );
-
-    overlayContainer.open();
-
-    return overlayRefConstructed;
-  }
-
-  /**
-   * Finds an open overlay by its id.
-   * @param id ID to use when looking up the overlay.
-   */
-  getOverlayById(id: string): R | undefined {
-    return this.openOverlays.find((overlay) => overlay.id === id);
-  }
-
-  /** Keeps track of the currently-open overlays. */
-  get openOverlays(): R[] {
-    return this.parentService ? this.parentService.openOverlays : this.#openOverlaysAtThisLevel;
-  }
-
-  /**
-   * Closes all currently-open overlays.
-   */
-  closeAll(): void {
-    // We have to copy the array first as the array is mutated during the iteration.
-    this.openOverlays.slice().forEach((ref: R) => ref.close());
-  }
-
   #getAfterAllClosed(): Subject<void> {
     const parent = this.parentService;
     return parent ? parent.#getAfterAllClosed() : this.#afterAllClosedAtThisLevel;
-  }
-
-  /**
-   * Stream that emits when all open overlays have finished closing.
-   * Will emit on subscribe if there are no open overlays to begin with.
-   */
-  readonly afterAllClosed: Observable<void> = defer(
-    () =>
-      this.openOverlays.length
-        ? this.#getAfterAllClosed()
-        : this.#getAfterAllClosed().pipe(startWith(undefined)),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) as Observable<any>;
-
-  /** Stream that emits when an overlay has been opened. */
-  get afterOpened(): Subject<R> {
-    return this.parentService ? this.parentService.afterOpened : this.#afterOpenedAtThisLevel;
-  }
-
-  protected abstract parentService: SbbOverlayBaseService<C, I, R> | null;
-  protected abstract containerType: Type<C>;
-  protected abstract refConstructor: Type<R>;
-  protected abstract configType: Type<unknown>;
-  protected overlayDataToken: InjectionToken<unknown> = SBB_OVERLAY_DATA;
-
-  #injector = inject(Injector);
-
-  protected constructor() {
-    /* empty */
-  }
-
-  ngOnDestroy() {
-    // Make a second pass and close the remaining dialogs. We do this second pass in order to
-    // correctly dispatch the `afterAllClosed` event in case we have a mixed array of dialogs
-    // that should be closed and dialogs that should not.
-    this.#openOverlaysAtThisLevel.reverse().forEach((dialog) => dialog.close());
-    this.#afterAllClosedAtThisLevel.complete();
-    this.#afterOpenedAtThisLevel.complete();
-    this.#openOverlaysAtThisLevel = [];
   }
 
   #removeOpenOverlay(overlayRef: R, emitEvent: boolean): void {

--- a/src/angular/core/overlay/overlay-base.ts
+++ b/src/angular/core/overlay/overlay-base.ts
@@ -148,7 +148,10 @@ export abstract class SbbOverlayBaseService<
   }
 
   /** Method meant to be overridden by derived class (e.g. dialog) to configure the element after attaching it. */
-  protected configureContainer(_element: HTMLElement, _config: SbbOverlayBaseConfig<C, I>): void {
+  protected setupContainerElement(
+    _element: HTMLElement,
+    _config: SbbOverlayBaseConfig<C, I>,
+  ): void {
     // no-op
   }
 
@@ -192,7 +195,9 @@ export abstract class SbbOverlayBaseService<
     );
     const componentRef = portalOutlet.attach(containerPortal);
 
-    this.configureContainer(componentRef.location.nativeElement, config);
+    this.setupContainerElement(componentRef.location.nativeElement, config);
+
+    config.setupContainer?.(componentRef.instance.elementInstance as I);
 
     const ngZone = this.#injector.get(NgZone);
     if (typeof componentRef?.onDestroy === 'function') {
@@ -216,9 +221,6 @@ export abstract class SbbOverlayBaseService<
         }
       });
     }
-
-    config.setupContainer?.(componentRef.instance.elementInstance as I);
-
     return componentRef.instance;
   }
 

--- a/src/angular/core/overlay/overlay-base.ts
+++ b/src/angular/core/overlay/overlay-base.ts
@@ -194,6 +194,7 @@ export abstract class SbbOverlayBaseService<
 
     this.configureContainer(componentRef.location.nativeElement, config);
 
+    const ngZone = this.#injector.get(NgZone);
     if (typeof componentRef?.onDestroy === 'function') {
       // In most cases we control the portal and we know when it is being detached so that
       // we can finish the disposal process. The exception is if the user passes in a custom
@@ -202,7 +203,6 @@ export abstract class SbbOverlayBaseService<
       // reattach the overlay at a later point. It also has the advantage of waiting for animations.
       componentRef.onDestroy(() => {
         if (portalOutlet.hasAttached()) {
-          const ngZone = this.#injector.get(NgZone);
           // We have to delay the `detach` call, because detaching immediately prevents
           // other destroy hooks from running. This is likely a framework bug similar to
           // https://github.com/angular/angular/issues/46119

--- a/src/angular/dialog/dialog/dialog-config.ts
+++ b/src/angular/dialog/dialog/dialog-config.ts
@@ -9,16 +9,16 @@ export class SbbDialogConfig<
   I = SbbDialog,
   D = unknown,
 > extends SbbOverlayBaseConfig<C, I, D> {
-  /** The width of the dialog. If a number is provided, pixel units are assumed. */
+  /** The width of the dialog. Can be any valid CSS value, also including CSS variables. If a number is provided, pixel units are assumed. */
   width?: number | string;
 
-  /** The height of the dialog. If a number is provided, pixel units are assumed. */
+  /** The height of the dialog. Can be any valid CSS value, also including CSS variables. If a number is provided, pixel units are assumed. */
   height?: number | string;
 
-  /** The max-width of the dialog. If a number is provided, pixel units are assumed. */
+  /** The max-width of the dialog. Can be any valid CSS value, also including CSS variables. If a number is provided, pixel units are assumed. */
   maxWidth?: number | string;
 
-  /** The max-height of the dialog. If a number is provided, pixel units are assumed. */
+  /** The max-height of the dialog. Can be any valid CSS value, also including CSS variables. If a number is provided, pixel units are assumed. */
   maxHeight?: number | string;
 
   /**

--- a/src/angular/dialog/dialog/dialog-config.ts
+++ b/src/angular/dialog/dialog/dialog-config.ts
@@ -9,6 +9,18 @@ export class SbbDialogConfig<
   I = SbbDialog,
   D = unknown,
 > extends SbbOverlayBaseConfig<C, I, D> {
+  /** The width of the dialog. If a number is provided, pixel units are assumed. */
+  width?: number | string;
+
+  /** The height of the dialog. If a number is provided, pixel units are assumed. */
+  height?: number | string;
+
+  /** The max-width of the dialog. If a number is provided, pixel units are assumed. */
+  maxWidth?: number | string;
+
+  /** The max-height of the dialog. If a number is provided, pixel units are assumed. */
+  maxHeight?: number | string;
+
   /**
    * Providers that will be exposed to the contents of the dialog. Can also
    * be provided as a function in order to generate the providers lazily.

--- a/src/angular/dialog/dialog/dialog-service.ts
+++ b/src/angular/dialog/dialog/dialog-service.ts
@@ -18,6 +18,23 @@ export class SbbDialogService extends SbbOverlayBaseService<
   protected refConstructor = SbbDialogRef;
   protected configType = SbbDialogConfig;
 
+  protected override configureContainer(
+    element: HTMLElement,
+    config: SbbDialogConfig<SbbDialogContainer>,
+  ): void {
+    this.#updateSizeProp(element, '--sbb-dialog-width', config.width);
+    this.#updateSizeProp(element, '--sbb-dialog-height', config.height);
+    this.#updateSizeProp(element, '--sbb-dialog-max-width', config.maxWidth);
+    this.#updateSizeProp(element, '--sbb-dialog-max-height', config.maxHeight);
+  }
+
+  #updateSizeProp(element: HTMLElement, cssVar: string, prop: string | number | undefined): void {
+    if (!prop) {
+      return;
+    }
+    element.style.setProperty(cssVar, typeof prop === 'string' ? prop : `${prop}px`);
+  }
+
   public override open<T = unknown, R = unknown>(
     componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
     config?: SbbDialogConfig<SbbDialogContainer>,

--- a/src/angular/dialog/dialog/dialog-service.ts
+++ b/src/angular/dialog/dialog/dialog-service.ts
@@ -18,7 +18,7 @@ export class SbbDialogService extends SbbOverlayBaseService<
   protected refConstructor = SbbDialogRef;
   protected configType = SbbDialogConfig;
 
-  protected override configureContainer(
+  protected override setupContainerElement(
     element: HTMLElement,
     config: SbbDialogConfig<SbbDialogContainer>,
   ): void {

--- a/src/angular/dialog/readme.md
+++ b/src/angular/dialog/readme.md
@@ -157,6 +157,25 @@ export class ParentComponent {
 }
 ```
 
+The configuration object also allows to explicitly set the dialog dimensions when the dialog is opened via `SbbDialogService`.
+The variables accept both numbers, which are converted in pixel, and strings.
+
+```ts
+@Component({/* ... */})
+export class ParentComponent {
+  dialogService = inject(SbbDialogService);
+
+  openDialog() {
+    let dialogRef = dialog.open(YourDialog, {
+      height: '16rem',
+      width: 400,
+      minHeight: 'calc(100% - var(--sbb-spacing-fixed-2x))',
+      minWidth: 'auto',
+    });
+  }
+}
+```
+
 ### Sharing data with the slotted component.
 
 If you want to share data with the component rendered in your dialog, you can use the `data` property in the configuration object.

--- a/src/docs/app/angular/examples/dialog/dialog-dimensions/dialog-dimensions-example.html
+++ b/src/docs/app/angular/examples/dialog/dialog-dimensions/dialog-dimensions-example.html
@@ -1,0 +1,35 @@
+<sbb-secondary-button (click)="openDialog()">Open Dialog</sbb-secondary-button>
+<p>
+  Use controls to set the dialog dimensions; any value is accepted as per specification (e.g.
+  <sbb-link
+    href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/height#formal_syntax"
+    target="_blank"
+    >height formal syntax</sbb-link
+  >).
+</p>
+
+<sbb-title level="5">Properties</sbb-title>
+<div class="sbb-controls-table">
+  <label for="long-content">Long content</label>
+  <sbb-checkbox id="long-content" [formField]="dimensions.longContent"></sbb-checkbox>
+
+  <label for="height">Height</label>
+  <sbb-form-field size="s">
+    <input id="height" [formField]="dimensions.height" />
+  </sbb-form-field>
+
+  <label for="width">Width</label>
+  <sbb-form-field size="s">
+    <input id="width" [formField]="dimensions.width" />
+  </sbb-form-field>
+
+  <label for="max-height">Max height</label>
+  <sbb-form-field size="s">
+    <input id="max-height" [formField]="dimensions.maxHeight" />
+  </sbb-form-field>
+
+  <label for="max-width">Max width</label>
+  <sbb-form-field size="s">
+    <input id="max-width" [formField]="dimensions.maxWidth" />
+  </sbb-form-field>
+</div>

--- a/src/docs/app/angular/examples/dialog/dialog-dimensions/dialog-dimensions-example.ts
+++ b/src/docs/app/angular/examples/dialog/dialog-dimensions/dialog-dimensions-example.ts
@@ -1,0 +1,91 @@
+import { Component, inject, signal } from '@angular/core';
+import { form, FormField } from '@angular/forms/signals';
+import { SbbButtonModule } from '@sbb-esta/lyne-angular/button';
+import { SbbCheckboxModule } from '@sbb-esta/lyne-angular/checkbox';
+import { SBB_OVERLAY_DATA } from '@sbb-esta/lyne-angular/core';
+import { SbbDialogModule, SbbDialogService } from '@sbb-esta/lyne-angular/dialog';
+import { SbbFormFieldModule } from '@sbb-esta/lyne-angular/form-field';
+import { SbbLinkModule } from '@sbb-esta/lyne-angular/link';
+import { SbbTitleModule } from '@sbb-esta/lyne-angular/title';
+
+@Component({
+  selector: 'sbb-dialog-dimensions-content-example',
+  template: `
+    <sbb-dialog-title>Title</sbb-dialog-title>
+    <sbb-dialog-content>
+      <p>Content</p>
+      @if (dialogData) {
+        @for (_i of [].constructor(10); track _i) {
+          <p>
+            {{ dialogData }}
+          </p>
+        }
+      }
+    </sbb-dialog-content>
+    <sbb-dialog-actions>
+      <sbb-button sbb-dialog-close="confirm" sbb-focus-initial>Confirm</sbb-button>
+    </sbb-dialog-actions>
+  `,
+  imports: [SbbButtonModule, SbbDialogModule],
+})
+export class DialogDimensionsContentExample {
+  protected dialogData = inject<string>(SBB_OVERLAY_DATA, { optional: true }) ?? null;
+}
+
+/**
+ * @title dialog opened via service with dimensions set
+ * @order 10
+ */
+@Component({
+  selector: 'sbb-dialog-dimensions-example',
+  templateUrl: 'dialog-dimensions-example.html',
+  imports: [
+    FormField,
+    SbbButtonModule,
+    SbbCheckboxModule,
+    SbbLinkModule,
+    SbbFormFieldModule,
+    SbbTitleModule,
+  ],
+})
+export class DialogDimensionsExample {
+  protected static loremIpsum = `
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+    labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+    laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+    voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+    non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  `;
+
+  protected dimensions = form(
+    signal({
+      height: '',
+      width: '',
+      maxHeight: '',
+      maxWidth: '',
+      longContent: false,
+    }),
+  );
+
+  private dialogService = inject(SbbDialogService);
+
+  protected openDialog(): void {
+    this.dialogService.open<DialogDimensionsContentExample, string>(
+      DialogDimensionsContentExample,
+      {
+        height: this.convertDimension(this.dimensions().value().height),
+        width: this.convertDimension(this.dimensions().value().width),
+        maxHeight: this.convertDimension(this.dimensions().value().maxHeight),
+        maxWidth: this.convertDimension(this.dimensions().value().maxWidth),
+        data: this.dimensions().value().longContent ? DialogDimensionsExample.loremIpsum : null,
+      },
+    );
+  }
+
+  private convertDimension(d: string): string | number | undefined {
+    if (!d) {
+      return undefined;
+    }
+    return isNaN(Number(d)) ? d : Number(d);
+  }
+}

--- a/src/docs/app/angular/examples/dialog/index.ts
+++ b/src/docs/app/angular/examples/dialog/index.ts
@@ -1,3 +1,4 @@
+export { DialogDimensionsExample } from './dialog-dimensions/dialog-dimensions-example';
 export { DialogNestedExample } from './dialog-nested/dialog-nested-example';
 export { DialogServiceExample } from './dialog-service/dialog-service-example';
 export { DialogSharedDataExample } from './dialog-shared-data/dialog-shared-data-example';

--- a/src/docs/app/shared/example-module.ts
+++ b/src/docs/app/shared/example-module.ts
@@ -79,7 +79,13 @@ export const EXAMPLE_COMPONENTS: Record<string, (string | Partial<ExampleData>)[
     'date-input-template-driven',
   ],
   datepicker: ['datepicker-showcase', 'datepicker-basic'],
-  dialog: ['dialog-showcase', 'dialog-service', 'dialog-nested', 'dialog-shared-data'],
+  dialog: [
+    'dialog-showcase',
+    'dialog-service',
+    'dialog-nested',
+    'dialog-shared-data',
+    'dialog-dimensions',
+  ],
   divider: [{ id: 'divider-basic', hasStyle: true }],
   download: ['download-showcase', 'download-custom-content'],
   'easter-egg': ['easter-egg-basic'],
@@ -317,6 +323,7 @@ export async function loadExample(id: string): Promise<Record<string, Type<unkno
     case 'datepicker-basic':
     case 'datepicker-showcase':
       return import('../angular/examples/datepicker');
+    case 'dialog-dimensions':
     case 'dialog-nested':
     case 'dialog-service':
     case 'dialog-shared-data':


### PR DESCRIPTION
Closes #208 

Changes:
- the `SbbDialogConfig` has 4 new props (width, height, maxWidth and maxHeight);
- the properties and methods in the `SbbOverlayBaseService` has been reordered;
    - in the `#attachContainer`, a call to the new `configureContainer` method has been added;
    - the `configureContainer` is protected and empty;
- the `SbbDialogService` overrides the base method by setting the `--sbb-dialog-<variables>` reading the values from the `SbbDialogConfig`.